### PR TITLE
Add Code of Conduct to repo. Note in README.

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,50 @@
+# Contributor Code of Conduct
+
+As contributors and maintainers of this project, and in the interest of
+fostering an open and welcoming community, we pledge to respect all people who
+contribute through reporting issues, posting feature requests, updating
+documentation, submitting pull requests or patches, and other activities.
+
+We are committed to making participation in this project a harassment-free
+experience for everyone, regardless of level of experience, gender, gender
+identity and expression, sexual orientation, disability, personal appearance,
+body size, race, ethnicity, age, religion, or nationality.
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery
+* Personal attacks
+* Trolling or insulting/derogatory comments
+* Public or private harassment
+* Publishing other's private information, such as physical or electronic
+  addresses, without explicit permission
+* Other unethical or unprofessional conduct
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+By adopting this Code of Conduct, project maintainers commit themselves to
+fairly and consistently applying these principles to every aspect of managing
+this project. Project maintainers who do not follow or enforce the Code of
+Conduct may be permanently removed from the project team.
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community.
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting a project maintainer at [INSERT EMAIL ADDRESS]. All
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. Maintainers are
+obligated to maintain confidentiality with regard to the reporter of an
+incident.
+
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 1.3.0, available at
+[http://contributor-covenant.org/version/1/3/0/][version]
+
+[homepage]: http://contributor-covenant.org
+[version]: http://contributor-covenant.org/version/1/3/0/

--- a/README.md
+++ b/README.md
@@ -11,3 +11,9 @@ Features
 * will produce qr code to allow people to sign up for events
 * Will contact members via email, SMS over email and VOIP to alert them
 * Will capture availablity via VOIP IVR, SMS and email
+
+#### Contributing to LIMS: Community Expectations :raised_hands:
+
+We have a [Code of Conduct](https://github.com/kgf/CODE_OF_CONDUCT.md) to set clear expectations for community participation. We want participating in LIMS to be safe, fun, and respectful. We've adopted the ["Contributor Covenant"](http://contributor-covenant.org/) model for our code of conduct, which is the same model that [the Rails project itself](http://rubyonrails.org/conduct/) uses. (Other projects that use a Code of Conduct of this type include [RSpec](https://github.com/rspec/rspec/blob/master/code_of_conduct.md), [Jenkins](https://jenkins-ci.org/conduct/), and [RubyGems](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).)
+
+Please read the [Code of Conduct](https://github.com/kgf/CODE_OF_CONDUCT.md). By participating in this project you agree to abide by its terms.


### PR DESCRIPTION
Why? I like this note: "If you think it's obvious that you shouldn't harass people... then you are not the person the policy is written for." - Ashe Dryden's [Codes of Conduct FAQ](http://www.ashedryden.com/blog/codes-of-conduct-101-faq)

As I mention in the README in this PR, the new code of conduct is the same one that Rails, RSpec, Bundler, and Jenkins adapted for their projects.

Another note: "The people most affected by harassing or assaulting behavior tend to be in the minority and are less likely to be visible. As high-profile members of our communities, setting the tone for the event up front is important. Having visible people of authority advocate for a safe space for them goes a long way." - [Geek Feminism](http://geekfeminism.wikia.com/wiki/Anti-harassment_policy_resources)

The [two](http://www.ashedryden.com/blog/codes-of-conduct-101-faq) [pages](http://geekfeminism.wikia.com/wiki/Anti-harassment_policy_resources) I just linked discuss benefits & responsibities in more detail. Some of the discussion is focused on conferences more than online community, but you might also consider this [timeline of incidents](http://geekfeminism.wikia.com/wiki/Timeline_of_incidents) and this [breakdown of communication issues in open source](http://geekfeminism.wikia.com/wiki/FLOSS#Issues).

_Alternative:_ Another example of a community code of conduct which we could consider adapting is [Rust's](https://www.rust-lang.org/conduct.html) policy.
