### PR TITLE
schema.rb has changed. (Original migrations gone?)

### DIFF
--- a/db/migrate/20121020093514_add_status_to_inspections.rb
+++ b/db/migrate/20121020093514_add_status_to_inspections.rb
@@ -1,5 +1,0 @@
-class AddStatusToInspections < ActiveRecord::Migration
-  def change
-      add_column :inspections, :status, :string
-  end
-end

--- a/db/migrate/20130516195515_addsourcetoitem.rb
+++ b/db/migrate/20130516195515_addsourcetoitem.rb
@@ -4,7 +4,6 @@ class Addsourcetoitem < ActiveRecord::Migration
     add_column :items, :grantstart, :date
     add_column :items, :grantexpiration, :date
     add_index "certs", ["person_id"], :name => "index_certs_on_person_id"
-    add_index "inspections", ["person_id"], :name => "index_inspections_on_person_id"
   end
 
 end

--- a/db/migrate/20130820214554_correct_field_names_to_time_not_date.rb
+++ b/db/migrate/20130820214554_correct_field_names_to_time_not_date.rb
@@ -2,12 +2,10 @@ class CorrectFieldNamesToTimeNotDate < ActiveRecord::Migration
   def up
     rename_column :events, :start_date, :start_time
     rename_column :events, :end_date, :end_time
-    rename_column :inspections, :inspection_date, :inspection_time
   end
 
   def down
     rename_column :events, :start_time, :start_date
     rename_column :events, :end_time, :end_date
-    rename_column :inspections, :inspection_time, :inspection_date
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -139,6 +139,7 @@ ActiveRecord::Schema.define(:version => 20160115231033) do
   add_index "inspections", ["item_id"], :name => "index_inspections_on_item_id"
 
   create_table "items", :force => true do |t|
+    t.integer  "location_id"
     t.string   "name"
     t.string   "description"
     t.string   "source"
@@ -165,7 +166,6 @@ ActiveRecord::Schema.define(:version => 20160115231033) do
     t.string   "stock_number"
     t.text     "comments"
     t.string   "item_image"
-    t.integer  "location_id"
   end
 
   create_table "locations", :force => true do |t|
@@ -187,16 +187,14 @@ ActiveRecord::Schema.define(:version => 20160115231033) do
   end
 
   create_table "messages", :force => true do |t|
-    t.integer  "recipient_id"
-    t.string   "status"
-    t.string   "channel"
-    t.datetime "processed_at"
-    t.string   "processed_by"
-    t.string   "slug"
-    t.datetime "created_at",   :null => false
-    t.datetime "updated_at",   :null => false
-    t.text     "body"
     t.string   "subject"
+    t.string   "status"
+    t.string   "body"
+    t.string   "channels"
+    t.datetime "sent_at"
+    t.integer  "created_by"
+    t.datetime "created_at", :null => false
+    t.datetime "updated_at", :null => false
   end
 
   create_table "moves", :force => true do |t|
@@ -207,23 +205,6 @@ ActiveRecord::Schema.define(:version => 20160115231033) do
     t.string   "reason"
     t.datetime "created_at",     :null => false
     t.datetime "updated_at",     :null => false
-  end
-
-  create_table "notifications", :force => true do |t|
-    t.integer  "event_id"
-    t.integer  "author_id"
-    t.string   "status"
-    t.string   "channels"
-    t.string   "subject"
-    t.string   "body"
-    t.datetime "sent_at"
-    t.text     "comments"
-    t.datetime "created_at",   :null => false
-    t.datetime "updated_at",   :null => false
-    t.string   "priority"
-    t.string   "event_group"
-    t.string   "send_trigger"
-    t.integer  "ttl"
   end
 
   create_table "people", :force => true do |t|
@@ -287,15 +268,6 @@ ActiveRecord::Schema.define(:version => 20160115231033) do
     t.datetime "updated_at",       :null => false
   end
 
-  create_table "recipients", :force => true do |t|
-    t.integer  "person_id"
-    t.integer  "notification_id"
-    t.string   "uuid"
-    t.string   "status"
-    t.datetime "created_at",      :null => false
-    t.datetime "updated_at",      :null => false
-  end
-
   create_table "repairs", :force => true do |t|
     t.integer  "item_id"
     t.integer  "user_id"
@@ -308,17 +280,6 @@ ActiveRecord::Schema.define(:version => 20160115231033) do
     t.datetime "created_at",                                 :null => false
     t.datetime "updated_at",                                 :null => false
     t.decimal  "cost",         :precision => 8, :scale => 2
-  end
-
-  create_table "responses", :force => true do |t|
-    t.integer  "recipient_id"
-    t.string   "intention"
-    t.datetime "eta"
-    t.datetime "etd"
-    t.decimal  "duration",     :precision => 5, :scale => 2
-    t.string   "channel"
-    t.datetime "created_at",                                 :null => false
-    t.datetime "updated_at",                                 :null => false
   end
 
   create_table "roles", :force => true do |t|


### PR DESCRIPTION
Running migrations produces these changes.

_[Edit:]_  This PR changes `schema.rb` by removing
three tables and altering a fourth table.  However, I
can't find any previous migrations in the repo that
would have created the tables as they are before
this PR.
