### PR TITLE
Remove occasional requires of absent rails_helper.

### DIFF
--- a/spec/models/department_spec.rb
+++ b/spec/models/department_spec.rb
@@ -1,4 +1,4 @@
-require 'rails_helper'
+require 'spec_helper'
 
 RSpec.describe Department, :type => :model do
   pending "add some examples to (or delete) #{__FILE__}"

--- a/spec/models/resource_type_spec.rb
+++ b/spec/models/resource_type_spec.rb
@@ -1,4 +1,3 @@
-#require 'rails_helper'
 require 'spec_helper'
 
 RSpec.describe ResourceType, :type => :model do

--- a/spec/requests/departments_spec.rb
+++ b/spec/requests/departments_spec.rb
@@ -1,4 +1,4 @@
-require 'rails_helper'
+require 'spec_helper'
 
 RSpec.describe "Departments", :type => :request do
   describe "GET /departments" do

--- a/spec/requests/resource_types_spec.rb
+++ b/spec/requests/resource_types_spec.rb
@@ -1,4 +1,4 @@
-require 'rails_helper'
+require 'spec_helper'
 
 RSpec.describe "ResourceTypes", :type => :request do
   describe "GET /resource_types" do

--- a/spec/routing/departments_routing_spec.rb
+++ b/spec/routing/departments_routing_spec.rb
@@ -1,4 +1,4 @@
-require "rails_helper"
+require "spec_helper"
 
 RSpec.describe DepartmentsController, :type => :routing do
   describe "routing" do

--- a/spec/routing/resource_types_routing_spec.rb
+++ b/spec/routing/resource_types_routing_spec.rb
@@ -1,4 +1,4 @@
-require "rails_helper"
+require "spec_helper"
 
 RSpec.describe ResourceTypesController, :type => :routing do
   describe "routing" do


### PR DESCRIPTION
`rails_helper.rb` is reportedly the preferred RSpec way going forward, but these 5 includes were a bit hasty.
