### PR TITLE
channels no longer duplicated when updating a person

### DIFF
--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -98,6 +98,7 @@ class PeopleController < ApplicationController
 
   def edit
     @person = Person.includes(:phones, :emails).find(params[:id])
+    @page_title = @person.fullname
   end
 
   def create
@@ -151,8 +152,8 @@ class PeopleController < ApplicationController
       :title, :gender, :date_of_birth, :division1,
       :division2, :channels_attributes, :title_ids,
       :title_order, :comments,
-      phones_attributes: [:category, :content, :name, :status, :usage, :carrier, :sms_available, :priority, :channel_type],
-      emails_attributes: [:category, :content, :name, :status, :usage]
+      phones_attributes: [:id, :category, :content, :name, :status, :usage, :carrier, :sms_available, :priority, :channel_type],
+      emails_attributes: [:id, :category, :content, :name, :status, :usage]
     )
   end
 end

--- a/app/views/people/_form.html.erb
+++ b/app/views/people/_form.html.erb
@@ -14,6 +14,7 @@
       <h2> Phone information </h2>
       <%= f.simple_fields_for :phones do |c| %>
         <fieldset>
+          <%= c.input :id, :as => :hidden %>
           <%= c.input :category, :as => :select, :collection => Channel::CATEGORIES %>
           <%= c.input :content, :placeholder => '9785551212' %>
           <%= c.input :name, :label => 'Description' %>
@@ -31,6 +32,7 @@
       <h2> Email information </h2>
       <%= f.simple_fields_for :emails do |c| %>
         <fieldset>
+          <%= c.input :id, :as => :hidden %>
           <%= c.input :category, :as => :select, :collection => Channel::CATEGORIES %>
           <%= c.input :content, :placeholder => 'me@example.com' %>
           <%= c.input :name, :label => 'Description' %>

--- a/spec/features/person_edit_spec.rb
+++ b/spec/features/person_edit_spec.rb
@@ -47,6 +47,18 @@ describe "Person" do
       expect(page).not_to have_content("Error")
     end
 
+    it "does not duplicate channels on update" do
+      cj = create(:person, firstname: 'CJ',  department: 'Police' )
+      cj.channels << create(:channel, type: "Phone", channel_type: 'Phone', content: '9785551212', category: "Mobile Phone")
+      expect {
+        visit edit_person_path(cj)
+        fill_in('Zipcode', :with => '02108')
+        click_button "Update Person"
+        expect(page).not_to have_content("Error")
+        expect(cj.reload.zipcode).to eq("02108")
+      }.not_to change(Channel, :count)
+    end
+
     it "qualified only if all skills are present" do
       title = create(:title, name: "Police Officer")
       drivingskill = create(:skill, name: "Driving")


### PR DESCRIPTION
Resolves https://github.com/kgf/lims/issues/60

I discovered a tangential bug while investigating this and https://github.com/kgf/lims/issues/99 

repro:
- create a new person with at least one channel (I filled in both phone number and email). save.
- navigate back to the new person's show page and click edit. without making any changes, click "Update Person."
- navigate back to the person's show page.
- observe.

expected:
I only see the phone number and email once.

actual:
phone number and email are duplicated. console shows the user now has 4 channels. Note that if I repeat this, I will have 8, then 16, etc.
