### PR TITLE
Visually Merge Event Timecard Tables

### DIFF
--- a/app/assets/stylesheets/events.scss
+++ b/app/assets/stylesheets/events.scss
@@ -14,3 +14,19 @@
 .ui-timepicker-rtl dl { text-align: right; padding: 0 5px 0 0; }
 .ui-timepicker-rtl dl dt{ float: right; clear: right; }
 .ui-timepicker-rtl dl dd { margin: 0 45% 10px 10px; }
+
+#event_timecards {
+  border: 1px solid #e1e1e8;
+  padding: 9px 14px;
+  border-radius: 4px;
+  // background-color: #f7f7f9;
+
+  h3 {
+    padding-bottom: 8px;
+    font-size: 16px;
+  }
+
+  th{
+    color: #666;
+  }
+}

--- a/app/views/events/_all_for_event.html.erb
+++ b/app/views/events/_all_for_event.html.erb
@@ -1,41 +1,37 @@
-<div class="accordion">
-  <h3>All timecards (Debugging) <%= @event.timecards.count %></h3>
-  <div>
-    <table id="all-timecards" class="table table-striped table-bordered">
-      <thead>
-        <tr>
-          <th>Name</th>
-          <th>Description</th>
-          <th>Intention</th>
-          <th>Intented Start</th>
-          <th>Intented End</th>
-          <th>Intented Hours</th>
-          <th>Outcome</th>
-          <th>Actual Start</th>
-          <th>Actual End</th>
-          <th>Actual Hours</th>
+<h3>All timecards (Debugging) <%= @event.timecards.count %></h3>
+<table id="all-timecards" class="table table-striped table-bordered">
+  <thead>
+    <tr>
+      <th>Name</th>
+      <th>Description</th>
+      <th>Intention</th>
+      <th>Intented Start</th>
+      <th>Intented End</th>
+      <th>Intented Hours</th>
+      <th>Outcome</th>
+      <th>Actual Start</th>
+      <th>Actual End</th>
+      <th>Actual Hours</th>
 
-          <th colspan = 2></th>
-        </tr>
-      </thead>
-      <tbody>
-        <% @event.timecards.each do |timecard| %>
-          <tr>
-            <td><%= link_to timecard.person.fullname, timecard %></td>
-            <td><%= timecard.description %></td>
-            <td><%= timecard.intention  %></td>
-            <td><%= timecard.intended_start_time  %></td>
-            <td><%= timecard.intended_end_time %></td>
-            <td><%= timecard.intended_duration %></td>
-            <td><%= timecard.outcome  %></td>
-            <td><%= timecard.actual_start_time  %></td>
-            <td><%= timecard.actual_end_time %></td>
-            <td><%= timecard.actual_duration %></td>
-            <td><%= link_to 'Edit', edit_timecard_path(timecard), :class => "btn btn-mini" if can? :update, timecard %></td>
-            <td><%= link_to 'Delete', timecard_path(timecard), :method => :delete, :class => "btn btn-mini" if can? :destroy, timecard %></td>
-          </tr>
-        <% end %>
-      </tbody>
-    </table>
-  </div>
-</div>
+      <th colspan = 2></th>
+    </tr>
+  </thead>
+  <tbody>
+    <% @event.timecards.each do |timecard| %>
+      <tr>
+        <td><%= link_to timecard.person.fullname, timecard %></td>
+        <td><%= timecard.description %></td>
+        <td><%= timecard.intention  %></td>
+        <td><%= timecard.intended_start_time  %></td>
+        <td><%= timecard.intended_end_time %></td>
+        <td><%= timecard.intended_duration %></td>
+        <td><%= timecard.outcome  %></td>
+        <td><%= timecard.actual_start_time  %></td>
+        <td><%= timecard.actual_end_time %></td>
+        <td><%= timecard.actual_duration %></td>
+        <td><%= link_to 'Edit', edit_timecard_path(timecard), :class => "btn btn-mini" if can? :update, timecard %></td>
+        <td><%= link_to 'Delete', timecard_path(timecard), :method => :delete, :class => "btn btn-mini" if can? :destroy, timecard %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/events/_available_for_event.html.erb
+++ b/app/views/events/_available_for_event.html.erb
@@ -1,30 +1,26 @@
-<div class="accordion">
-  <h3>Available (<%= @event.available_people.count %>) </h3>
-  <div>
-    <table id="available" class="table table-striped table-bordered">
-      <thead>
-        <tr>
-          <th>Name</th>
-          <th>Start</th>
-          <th>End</th>
-          <th>Hours</th>
-          <th colspan=4 ></th>
-        </tr>
-      </thead>
-      <tbody>
-        <% @event.available_people.each do |timecard| %>
-          <tr>
-            <td><%= link_to timecard.person.fullname, timecard %></td>
-            <td><%= timecard.intended_start_time %></td>
-            <td><%= timecard.intended_end_time %></td>
-            <td><%= timecard.intended_duration %></td>
-            <td><%= unavailable_button(timecard) %></td>
-            <td><%= scheduled_button(timecard) %></td>
-            <td><%= worked_button(timecard) %></td>
-            <td><%= edit_button(timecard) %></td>
-          </tr>
-        <% end %>
-      </tbody>
-    </table>
-  </div>
-</div>
+<h3>Available (<%= @event.available_people.count %>) </h3>
+<table id="available" class="table table-striped table-bordered">
+  <thead>
+    <tr>
+      <th>Name</th>
+      <th>Start</th>
+      <th>End</th>
+      <th>Hours</th>
+      <th colspan=4 ></th>
+    </tr>
+  </thead>
+  <tbody>
+    <% @event.available_people.each do |timecard| %>
+      <tr>
+        <td><%= link_to timecard.person.fullname, timecard %></td>
+        <td><%= timecard.intended_start_time %></td>
+        <td><%= timecard.intended_end_time %></td>
+        <td><%= timecard.intended_duration %></td>
+        <td><%= unavailable_button(timecard) %></td>
+        <td><%= scheduled_button(timecard) %></td>
+        <td><%= worked_button(timecard) %></td>
+        <td><%= edit_button(timecard) %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/events/_scheduled_for_event.html.erb
+++ b/app/views/events/_scheduled_for_event.html.erb
@@ -1,32 +1,28 @@
-<div class="accordion">
-  <h3 id="scheduled-heading" >Scheduled (<%= @event.timecards.scheduled.count %>) <%#= @event.manhours %> </h3>
-  <div>
-    <table id="scheduled" class="table table-striped table-bordered">
-      <thead>
-        <tr>
-          <th>Name</th>
-          <th>Assignment</th>
-          <th>Start</th>
-          <th>End</th>
-          <th>Hours</th>
-          <th colspan=4 ></th>
-        </tr>
-      </thead>
-      <tbody>
-        <% @event.scheduled_people.each do |timecard| %>
-          <tr>
-            <td><%= link_to timecard.person.fullname, timecard %></td>
-            <td><%= timecard.description %></td>
-            <td><%= timecard.intended_start_time  %></td>
-            <td><%= timecard.intended_end_time %></td>
-            <td><%= timecard.intended_duration %></td>
-            <td><%= unavailable_button(timecard) %></td>
-            <td><%= available_button(timecard) %></td>
-            <td><%= worked_button(timecard) %></td>
-            <td><%= edit_button(timecard) %></td>
-          </tr>
-        <% end %>
-      </tbody>
-    </table>
-  </div>
-</div>
+<h3 id="scheduled-heading" >Scheduled (<%= @event.timecards.scheduled.count %>) <%#= @event.manhours %> </h3>
+<table id="scheduled" class="table table-striped table-bordered">
+  <thead>
+    <tr>
+      <th>Name</th>
+      <th>Assignment</th>
+      <th>Start</th>
+      <th>End</th>
+      <th>Hours</th>
+      <th colspan=4 ></th>
+    </tr>
+  </thead>
+  <tbody>
+    <% @event.scheduled_people.each do |timecard| %>
+      <tr>
+        <td><%= link_to timecard.person.fullname, timecard %></td>
+        <td><%= timecard.description %></td>
+        <td><%= timecard.intended_start_time  %></td>
+        <td><%= timecard.intended_end_time %></td>
+        <td><%= timecard.intended_duration %></td>
+        <td><%= unavailable_button(timecard) %></td>
+        <td><%= available_button(timecard) %></td>
+        <td><%= worked_button(timecard) %></td>
+        <td><%= edit_button(timecard) %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/events/_unavailable_for_event.html.erb
+++ b/app/views/events/_unavailable_for_event.html.erb
@@ -1,28 +1,24 @@
-<div class="accordion">
-  <h3>Unavailable (<%= @event.timecards.unavailable.count %>) </h3>
-  <div>
-    <table id="unavailable" class="table table-striped table-bordered">
-      <thead>
-        <tr>
-          <th>Name</th>
-          <th>Reason</th>
-          <th>Department</th>
-          <th colspan=4 ></th>
-        </tr>
-      </thead>
-      <tbody>
-        <% @event.timecards.unavailable.each do |timecard| %>
-          <tr>
-            <td><%= link_to timecard.person.fullname, timecard %></td>
-            <td><%= timecard.description %></td>
-            <td><%= timecard.person.department %></td>
-            <td><%= available_button(timecard) %></td>
-            <td><%= scheduled_button(timecard) %></td>
-            <td><%= worked_button(timecard) %></td>
-            <td><%= edit_button(timecard) %></td>
-          </tr>
-        <% end %>
-      </tbody>
-    </table>
-  </div>
-</div>
+<h3>Unavailable (<%= @event.timecards.unavailable.count %>) </h3>
+<table id="unavailable" class="table table-striped table-bordered">
+  <thead>
+    <tr>
+      <th>Name</th>
+      <th>Reason</th>
+      <th>Department</th>
+      <th colspan=4 ></th>
+    </tr>
+  </thead>
+  <tbody>
+    <% @event.timecards.unavailable.each do |timecard| %>
+      <tr>
+        <td><%= link_to timecard.person.fullname, timecard %></td>
+        <td><%= timecard.description %></td>
+        <td><%= timecard.person.department %></td>
+        <td><%= available_button(timecard) %></td>
+        <td><%= scheduled_button(timecard) %></td>
+        <td><%= worked_button(timecard) %></td>
+        <td><%= edit_button(timecard) %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/events/_unknown_for_event.html.erb
+++ b/app/views/events/_unknown_for_event.html.erb
@@ -1,44 +1,40 @@
-  <div class="accordion">
-    <h3>Unknown (<%= @event.unknown_people.count %>) </h3>
-    <div>
-      <table id="unknown" class="table table-striped table-bordered">
-        <thead>
-          <tr>
-            <th>Name</th>
-            <th>Phone</th>
-            <th>Division</th>
-            <th>Squad</th>
-            <th colspan=4></th>
-          </tr>
-        </thead>
-        <tbody>
-          <% @event.unknown_people.each do |person| %>
-            <tr>
-              <td><%= link_to person.fullname, person %></td>
-              <td><%= person.phones.map { |e| number_to_phone(e.content, area_code: true) }.join(',') %></td>
-              <td><%= person.division1 %></td>
-              <td><%= person.division2 %></td>
-              <% if can? :create, Timecard and @event.status.in? ["Scheduled", "In-session"] %>
-                <td>
-                  <%= link_to "Unavailable", schedule_path(@event, person.id, "Unavailable"), method: :Post, :class => 'btn btn-mini' %>
-                </td>
-                <td>
-                  <%= link_to "Available", schedule_path(@event, person.id, "Available"), method: :Post, :class => 'btn btn-mini' %>
-                </td>
-                <td>
-                  <%= link_to "Scheduled", schedule_path(@event, person.id, "Scheduled"), method: :Post, :class => 'btn btn-mini' %>
-                </td>
-              <% else %>
-                <td></td><td></td><td></td>
-              <% end %>
-              <% if can? :create, Timecard and @event.status.in? ["In-session", "Completed"] %>
-                <td><%= link_to "Worked", schedule_path(@event, person.id, "Worked"), method: :Post, :class => 'btn btn-mini' %></td>
-              <% else %>
-                <td></td>
-              <% end %>
-            </tr>
-          <% end %>
-        </tbody>
-      </table>
-    </div>
-  </div>
+<h3>Unknown (<%= @event.unknown_people.count %>) </h3>
+<table id="unknown" class="table table-striped table-bordered">
+  <thead>
+    <tr>
+      <th>Name</th>
+      <th>Phone</th>
+      <th>Division</th>
+      <th>Squad</th>
+      <th colspan=4></th>
+    </tr>
+  </thead>
+  <tbody>
+    <% @event.unknown_people.each do |person| %>
+      <tr>
+        <td><%= link_to person.fullname, person %></td>
+        <td><%= person.phones.map { |e| number_to_phone(e.content, area_code: true) }.join(',') %></td>
+        <td><%= person.division1 %></td>
+        <td><%= person.division2 %></td>
+        <% if can? :create, Timecard and @event.status.in? ["Scheduled", "In-session"] %>
+          <td>
+            <%= link_to "Unavailable", schedule_path(@event, person.id, "Unavailable"), method: :Post, :class => 'btn btn-mini' %>
+          </td>
+          <td>
+            <%= link_to "Available", schedule_path(@event, person.id, "Available"), method: :Post, :class => 'btn btn-mini' %>
+          </td>
+          <td>
+            <%= link_to "Scheduled", schedule_path(@event, person.id, "Scheduled"), method: :Post, :class => 'btn btn-mini' %>
+          </td>
+        <% else %>
+          <td></td><td></td><td></td>
+        <% end %>
+        <% if can? :create, Timecard and @event.status.in? ["In-session", "Completed"] %>
+          <td><%= link_to "Worked", schedule_path(@event, person.id, "Worked"), method: :Post, :class => 'btn btn-mini' %></td>
+        <% else %>
+          <td></td>
+        <% end %>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/events/_worked_for_event.html.erb
+++ b/app/views/events/_worked_for_event.html.erb
@@ -1,33 +1,29 @@
-<div class="accordion">
-  <h3>Worked (<%= @event.timecards.worked.count %>) <%#= @event.manhours %> </h3>
-  <div>
-    <table id="worked" class="table table-striped table-bordered">
-      <thead>
-        <tr>
-          <th>Name</th>
-          <th>Assignment</th>
-          <th>Intention</th>
-          <th>Outcome</th>
-          <th>Start</th>
-          <th>End</th>
-          <th>Hours</th>
-          <th></th>
-        </tr>
-      </thead>
-      <tbody>
-        <% @event.timecards.worked.each do |timecard| %>
-          <tr>
-            <td><%= link_to timecard.person.fullname, timecard %></td>
-            <td><%= timecard.description %></td>
-            <td><%= timecard.intention  %></td>
-            <td><%= timecard.outcome  %></td>
-            <td><%= timecard.actual_start_time  %></td>
-            <td><%= timecard.actual_end_time %></td>
-            <td><%= timecard.actual_duration %></td>
-            <td><%= edit_button(timecard) %></td>
-          </tr>
-        <% end %>
-      </tbody>
-    </table>
-  </div>
-</div>
+<h3>Worked (<%= @event.timecards.worked.count %>) <%#= @event.manhours %> </h3>
+<table id="worked" class="table table-striped table-bordered">
+  <thead>
+    <tr>
+      <th>Name</th>
+      <th>Assignment</th>
+      <th>Intention</th>
+      <th>Outcome</th>
+      <th>Start</th>
+      <th>End</th>
+      <th>Hours</th>
+      <th></th>
+    </tr>
+  </thead>
+  <tbody>
+    <% @event.timecards.worked.each do |timecard| %>
+      <tr>
+        <td><%= link_to timecard.person.fullname, timecard %></td>
+        <td><%= timecard.description %></td>
+        <td><%= timecard.intention  %></td>
+        <td><%= timecard.outcome  %></td>
+        <td><%= timecard.actual_start_time  %></td>
+        <td><%= timecard.actual_end_time %></td>
+        <td><%= timecard.actual_duration %></td>
+        <td><%= edit_button(timecard) %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/events/_working_for_event.html.erb
+++ b/app/views/events/_working_for_event.html.erb
@@ -1,31 +1,27 @@
-<div class="accordion">
-  <h3>Working (<%= @event.timecards.working.count %>) <%#= @event.manhours %> </h3>
-  <div>
-    <table id="working" class="table table-striped table-bordered">
-      <thead>
-        <tr>
-          <th>Name</th>
-          <th>Assignment</th>
-          <th>Intention</th>
-          <th>Outcome</th>
-          <th>Start</th>
-          <th>Hours</th>
-          <th></th>
-        </tr>
-      </thead>
-      <tbody>
-        <% @event.timecards.working.each do |timecard| %>
-          <tr>
-            <td><%= link_to timecard.person.fullname, timecard %></td>
-            <td><%= timecard.description %></td>
-            <td><%= timecard.intention  %></td>
-            <td><%= timecard.outcome  %></td>
-            <td><%= timecard.actual_start_time  %></td>
-            <td><%= elapsed_time(timecard) %></td>
-            <td><%= edit_button(timecard) %></td>
-          </tr>
-        <% end %>
-      </tbody>
-    </table>
-  </div>
-</div>
+<h3>Working (<%= @event.timecards.working.count %>) <%#= @event.manhours %> </h3>
+<table id="working" class="table table-striped table-bordered">
+  <thead>
+    <tr>
+      <th>Name</th>
+      <th>Assignment</th>
+      <th>Intention</th>
+      <th>Outcome</th>
+      <th>Start</th>
+      <th>Hours</th>
+      <th></th>
+    </tr>
+  </thead>
+  <tbody>
+    <% @event.timecards.working.each do |timecard| %>
+      <tr>
+        <td><%= link_to timecard.person.fullname, timecard %></td>
+        <td><%= timecard.description %></td>
+        <td><%= timecard.intention  %></td>
+        <td><%= timecard.outcome  %></td>
+        <td><%= timecard.actual_start_time  %></td>
+        <td><%= elapsed_time(timecard) %></td>
+        <td><%= edit_button(timecard) %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>


### PR DESCRIPTION
Take out the accordions and visually merge each table under the accordions to appear to be one table (though they are still separate tables in the markup). Add a 1px border around the `event_timecards` div with a color of `#e1e1e8`. Change `<h3>`'s font size to 16px and each `<th>` label to color `#666`. Remove unnecessary `<div>`s.

<img width="1234" alt="before-closed" src="https://cloud.githubusercontent.com/assets/13936766/17469435/f2811234-5d00-11e6-81f5-e9bc4784b431.png">

<img width="1326" alt="before-open" src="https://cloud.githubusercontent.com/assets/13936766/17469445/f910d04e-5d00-11e6-8ba4-bbb2ae2b709a.png">

<img width="1440" alt="after" src="https://cloud.githubusercontent.com/assets/13936766/17469453/118aa956-5d01-11e6-9415-de1b30f71247.png">
