### PR TITLE
Signin sheet can now enumerate division1 values

### DIFF
--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -6,6 +6,7 @@ class PeopleController < ApplicationController
   def signin
     #This is the sign-in sheet, not anything about authentication
     @people = Person.active
+    @department = "Police"
     @page_title = "Sign-in"
     render :layout => "print_signin"
   end

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -46,8 +46,8 @@ class Person < ActiveRecord::Base
 
   TITLES = ['Director','Chief','Deputy','Captain', 'Lieutenant','Sargeant', 'Corporal', 'Senior Officer', 'Officer', 'CERT Member', 'Dispatcher', 'Recruit']
   TITLE_ORDER = {'Director' => 1, 'Chief' => 3, 'Deputy Chief' => 5,'Captain' => 7, 'Lieutenant' => 9, 'Sargeant' => 11, 'Corporal' => 13, 'Senior Officer' => 15, 'Officer' => 17, 'CERT Member' => 19, 'Dispatcher' => 19, 'Student Officer' => 21, 'Recruit' => 23, 'Applicant' => 25}
-  DIVISION1 = ['Division 1', 'Division 2', 'Command']
-  DIVISION2 = ['Command', 'Squad 1', 'Squad 2', 'CERT']
+  DIVISION1 = ['Division 1', 'Division 2', "Division 3", "Recruit", 'Command']
+  DIVISION2 = ['Command', 'Squad 1', 'Squad 2']
   STATUS = ['Leave of Absence', 'Inactive', 'Active', 'Applicant','Prospect','Declined']
   DEPARTMENT = ['Police', 'CERT', 'Other']
 

--- a/app/views/people/_coc_boxes.html.erb
+++ b/app/views/people/_coc_boxes.html.erb
@@ -1,5 +1,5 @@
 <li class="<%= h p.title.downcase.split(" ")[0] -%>">
 	<%= h p.shortrank -%>
-	<%= h p.lastname -%> (<%= h p.icsid -%>)<br/>
+	<%= h p.firstname[0] + " " + p.lastname -%> (<%= h p.icsid -%>)<br/>
 	<%#= number_to_phone(p.contacts.first.content, :area_code => true) +    " " + p.contacts.first.category.split(" ")[0] if p.contacts.first -%>
 </li>

--- a/app/views/people/_signin_boxes.html.erb
+++ b/app/views/people/_signin_boxes.html.erb
@@ -1,7 +1,7 @@
 <tr>
-  <td class="<%= h p.title.downcase.split(" ")[0] %> id"><%= p.memberID %></td>
+  <td class="<%= h p.title.downcase.split(" ")[0] %> id"><%= p.icsid %></td>
   <td class="<%= h p.title.downcase.split(" ")[0] %> name">
-  <%= p.shortrank + " " + p.lastname %></td>
+  <%= p.shortrank + " " + p.firstname[0] + " " + p.lastname %></td>
   <td class= "signature">&nbsp</td>
   <td class= "time">&nbsp</td>
   <td class= "time">&nbsp</td>

--- a/app/views/people/signin.html.erb
+++ b/app/views/people/signin.html.erb
@@ -151,32 +151,17 @@ thead td.left {
   <thead>
    <tr><td colspan = 2 class="left">Date:</td><td class="left">Event:</td>
    <td >Time In</td><td>Time Out</td></tr>
-   <tr><td colspan = 5>Command Staff</td></tr>
   </thead>
-   <tbody>
-   <% Person.active.divisionC.each do |p| %>
-           <%= render :partial => 'signin_boxes', :locals => { :p => p} %>
+  <% Person.active.where(department: @department).pluck(:division1).uniq.each do |d1| %>
+    <thead>
+     <tr><td colspan = 5><%= d1 %></td></tr>
+    </thead>
+    <tbody>
+     <% Person.active.where(division1: d1).order(:title_order).each do |p| %>
+             <%= render :partial => 'signin_boxes', :locals => { :p => p} %>
+    <% end %>
+    </tbody>
   <% end %>
-  </tbody>
-  <thead>
-   <tr><td colspan = 5>Division 1</td></tr>
-  </thead>
-  <tbody>
-   <% Person.active.division1.each do |p| %>
-           <%= render :partial => 'signin_boxes', :locals => { :p => p} %>
-  <% end %>
-  </tbody>
-  <thead>
-   <tr><td colspan = 5>Division 2</td></tr>
-  </thead>
-  <tbody>
-   <% Person.active.division2.each do |p| %>
-           <%= render :partial => 'signin_boxes', :locals => { :p => p} %>
-  <% end %>
-  </tbody>
-  <thead>
-   <tr><td colspan = 5>Recruits</td></tr>
-  </thead>
   <tbody>
    <% 3.times do %>
            <%= render :partial => 'signin_blank_boxes' %>

--- a/spec/features/authorization_editor_spec.rb
+++ b/spec/features/authorization_editor_spec.rb
@@ -30,7 +30,7 @@ describe "a user" do
       @person_active = create(:person)
       @person_inactive = create(:person, status: 'Inactive')
       visit signin_people_path
-      expect(page).to have_content("Command Staff") #This is in the first heading
+      expect(page).to have_content("Command") #This is in the first heading
       expect(page).to have_content(@person_active.lastname)
       expect(page).not_to have_content(@person_inactive.lastname)
     end
@@ -70,7 +70,7 @@ describe "a user" do
       @person_active = create(:person)
       @person_inactive = create(:person, status: 'Inactive')
       visit signin_people_path
-      expect(page).to have_content("Command Staff") #This is in the first heading
+      expect(page).to have_content("Command") #This is in the first heading
       expect(page).to have_content(@person_active.lastname)
       expect(page).not_to have_content(@person_inactive.lastname)
     end

--- a/spec/features/authorization_reader_spec.rb
+++ b/spec/features/authorization_reader_spec.rb
@@ -30,7 +30,7 @@ describe "a user" do
       @person_active = create(:person)
       @person_inactive = create(:person, status: 'Inactive')
       visit signin_people_path
-      expect(page).to have_content("Command Staff") #This is in the first heading
+      expect(page).to have_content("Command") #This is in the first heading
       expect(page).to have_content(@person_active.lastname)
       expect(page).not_to have_content(@person_inactive.lastname)
     end

--- a/spec/features/authorization_trainer_spec.rb
+++ b/spec/features/authorization_trainer_spec.rb
@@ -29,7 +29,7 @@ describe "a user in the trainer role" do
     @person_active = create(:person)
     @person_inactive = create(:person, status: 'Inactive')
     visit signin_people_path
-    expect(page).to have_content("Command Staff") #This is in the first heading
+    expect(page).to have_content("Command") #This is in the first heading
     expect(page).to have_content(@person_active.lastname)
     expect(page).not_to have_content(@person_inactive.lastname)
   end


### PR DESCRIPTION
This means that when we get to the division 1 choices being a setting,
rather than a class constant, the report will still work.

This also addresses #58 
