### PR TITLE
validate chronology ; improve some views and specs

### DIFF
--- a/app/assets/javascripts/datatables_defaults.js
+++ b/app/assets/javascripts/datatables_defaults.js
@@ -3,6 +3,7 @@
 /* https://datatables.net/reference/option/ */
 
 $.extend( true, $.fn.dataTable.defaults, {
+  scrollCollapse: true,         // https://datatables.net/reference/option/scrollCollapse
   scrollY: '50vh',              // https://datatables.net/examples/basic_init/scroll_y_dynamic.html
   responsive: true,             // https://datatables.net/extensions/responsive/priority
   pagingType: "full_numbers",

--- a/app/assets/javascripts/inspections.js.coffee
+++ b/app/assets/javascripts/inspections.js.coffee
@@ -1,13 +1,13 @@
 jQuery ->
   $('#inspections').dataTable
     columnDefs: [
-                  ## https://datatables.net/extensions/responsive/priority
                   { orderable: false, targets: [4, 5] },
                 ]
 
 jQuery ->
   $('#item_inspections').dataTable
+    ## https://datatables.net/examples/basic_init/scroll_y_dynamic.html
+    scrollY: '20vh',
     columnDefs: [
-                  ## https://datatables.net/extensions/responsive/priority
                   { orderable: false, targets: [-1] },
                 ]

--- a/app/assets/javascripts/repairs.js.coffee
+++ b/app/assets/javascripts/repairs.js.coffee
@@ -1,13 +1,13 @@
 jQuery ->
   $('#repairs').dataTable
     columnDefs: [
-                  ## https://datatables.net/extensions/responsive/priority
                   { orderable: false, targets: [-1] },
                 ]
 
 jQuery ->
   $('#item_repairs').dataTable
+    ## https://datatables.net/examples/basic_init/scroll_y_dynamic.html
+    scrollY: '20vh',
     columnDefs: [
-                  ## https://datatables.net/extensions/responsive/priority
                   { orderable: false, targets: [-1] },
                 ]

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -87,27 +87,28 @@ module ApplicationHelper
     end
     link_to(name, '#', class: "add_fields", data: {id: id, fields: fields.gsub("\n", "")})
   end
-end
 
-# This is a general helper to provide a simple success or warning
-# label.  For anything more precise, a custom helper should be
-# used (as in items_helper.rb)
-def success_or_warning_label(str, success_str)
-  if str == success_str
-    return 'label-success'
-  else
-    return 'label-warning'
+  # This is a general helper to provide a simple success or warning
+  # label.  For anything more precise, a custom helper should be
+  # used (as in items_helper.rb)
+  def success_or_warning_label(str, success_str)
+    if str == success_str
+      return 'label-success'
+    else
+      return 'label-warning'
+    end
   end
-end
 
-# This is for providing a date for a form in an order that Rails can understand.
-# It should match the format used by the datepicker/datetimepicker widget.
-# See app.js.coffee.
-def format_date_value(date)
-  date.strftime("%Y-%m-%d") if date
-end
+  # This is for providing a date for a form in an order that Rails can understand.
+  # It should match the format used by the datepicker/datetimepicker widget.
+  # See app.js.coffee.
+  def format_date_value(date)
+    date.strftime("%Y-%m-%d") if date
+  end
 
-# As above, but for datetime.
-def format_datetime_value(datetime)
-  datetime.strftime("%Y-%m-%d %H:%M") if datetime
+  # As above, but for datetime.
+  def format_datetime_value(datetime)
+    datetime.strftime("%Y-%m-%d %H:%M") if datetime
+  end
+
 end

--- a/app/models/availability.rb
+++ b/app/models/availability.rb
@@ -2,6 +2,7 @@ class Availability < ActiveRecord::Base
   belongs_to :person
 
   validates_presence_of :person, :status, :start_time, :end_time
+  validates_chronology :start_time, :end_time
 
   STATUS = [ 'Available', 'Unavailable', "Cancelled" ]
 

--- a/app/models/cert.rb
+++ b/app/models/cert.rb
@@ -5,6 +5,7 @@ class Cert < ActiveRecord::Base
   mount_uploader :certification, CertificationUploader
   before_save :set_defaults
   validates_presence_of :status, :person_id, :course_id, :issued_date
+  validates_chronology :issued_date, :expiration_date
 
   scope :active, -> { where( expired: false ) }
 

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -4,12 +4,12 @@ class Event < ActiveRecord::Base
   attr_accessible :title, :description, :category, :course_id, :duration, :start_time, :end_time, :instructor, :location, :status, :timecard_ids, :person_ids, :comments
 
   validates_presence_of :category, :title, :status
-  validate :end_time_cannot_be_before_start
-  validates_presence_of :start_time
 
+  validates_presence_of :start_time
   # Currently we need an end time to provide proper ranges to the scopes.
   # This will need to be revisited
   validates_presence_of :end_time  #, :if => :completed?
+  validates_chronology :start_time, :end_time
 
   has_many :certs
   belongs_to :course
@@ -113,12 +113,4 @@ private
       self.duration = ((end_time - start_time) / 1.hour).round(2) || 0
     end
   end
-
-  def end_time_cannot_be_before_start
-    if ((!end_time.blank?) and (!start_time.blank?)) and end_time < start_time
-      errors.add(:end_time, "must be after the start, unless you are the Doctor")
-    end
-  end
-
-
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -8,6 +8,9 @@ class Item < ActiveRecord::Base
                   :department_id, :resource_type_id, :item_type_id,
                   :unique_ids_attributes
 
+  # validates_chronology :purchase_date, :sell_date     # ? - if so, needs a test
+  # validates_chronology :grantstart, :grantexpiration  # ? - if so, needs a test
+
   mount_uploader :item_image, ItemImageUploader
   validates_numericality_of :value
   belongs_to :owner, class_name: 'Person', inverse_of: :items

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -27,6 +27,7 @@ class Person < ActiveRecord::Base
   validates_numericality_of  :height, :weight, :allow_nil => true, :allow_blank => true
   validates_presence_of :division2, :unless => "division1.blank?"
   validates_presence_of :division1, :unless => "division2.blank?"
+  validates_chronology :start_date, :end_date
 
   scope :cert, -> { order("division1, division2, title_order, start_date ASC").where( department: "CERT" ) }
   scope :police, -> { order("division1, division2, title_order, start_date ASC").where( department: "Police" ) }

--- a/app/views/availabilities/_form.html.erb
+++ b/app/views/availabilities/_form.html.erb
@@ -3,15 +3,15 @@
 
   <div class="form-inputs">
     <%= f.association :person, collection: Person.active %>
-    <%= f.input :status, :as => :select,
-                :collection => (Availability::STATUS - ["Cancelled"]) %>
+    <%= f.input :status, :as => :select, :collection => (Availability::STATUS - ["Cancelled"]) %>
     <%= f.input :description %>
 
-    <%= f.input :start_time, :as => :string,
-                :input_html => { :class => 'datetimepicker', :size => 11 }  %>
-    <%= f.input :end_time, :as => :string,
-                :input_html => { :class => 'datetimepicker', :size => 11 }  %>
-
+    <%= f.input :start_time, as: :string,
+                input_html: { class: 'datetimepicker', size: 11,
+                              value: format_datetime_value(f.object.start_time) } %>
+    <%= f.input :end_time, as: :string,
+                input_html: { class: 'datetimepicker', size: 11,
+                              value: format_datetime_value(f.object.end_time) } %>
   </div>
 
   <div class="form-actions">

--- a/app/views/certs/_form.html.erb
+++ b/app/views/certs/_form.html.erb
@@ -1,14 +1,24 @@
 <%= simple_form_for @cert, :class => "well form-horizontal", :html => {:multipart => true} do |f| %>
+  <%= f.error_notification %>
+
+  <div class="form-inputs">
     <%= f.association :person %>
     <%= f.association :course %>
     <%= f.input :status, :as => :select, :collection => ['Active', 'Inactive'] %>
-    <%= f.input :level, :hint => 'eg. EMT-Basic', :input_html => { :size => 22 }  %>
-    <%= f.input :cert_number, :label => 'Certification Number', :hint => "eg. Driver's License S number", :input_html => { :size => 22 }  %>
-    <%= f.input :issued_date, :as => :string, :label => 'Issued Date', :input_html => { :class => "datepicker", :size => 11 }  %>
-    <%= f.input :expiration_date, :hint => 'Leave blank to set expiration date from course default', :as => :string, :input_html => { :class => "datepicker", :size => 11 }  %>
+    <%= f.input :level, :hint => 'eg. EMT-Basic', :input_html => { :size => 22 } %>
+    <%= f.input :cert_number, :label => 'Certification Number',:hint => "eg. Driver's License S number", :input_html => { :size => 22 } %>
+    <%= f.input :issued_date, as: :string, label: 'Issued Date',
+                input_html: { class: "datepicker", size: 11,
+                              value: format_date_value(f.object.issued_date) } %>
+    <%= f.input :expiration_date, as: :string,
+                hint: 'Leave blank to set expiration date from course default',
+                input_html: { class:"datepicker", size: 11,
+                              value: format_date_value(f.object.expiration_date) } %>
     <%= f.input :certification, :as => :file, :hint => 'Upload a scanned image of the documentation' %>
     <%= f.input :comments %>
-  
-    <%= f.button :submit, :label => 'Create Certification' %>
+  </div>
 
+  <div class="form-actions">
+    <%= f.button :submit, :label => 'Create Certification' %>
+  </div>
 <% end %>

--- a/app/views/channels/_form.html.erb
+++ b/app/views/channels/_form.html.erb
@@ -10,7 +10,9 @@
     <%= f.input :carrier %>
     <%= f.input :usage %>
     <%= f.input :status %>
-    <%= f.input :last_verified %>
+    <%= f.input :last_verified, as: :string,
+                input_html: { class: "datetimepicker", size: 11,
+                              value: format_datetime_value(f.object.last_verified) } %>
   </div>
 
   <div class="form-actions">

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -16,8 +16,10 @@
   </div>
 <% end %>
 
-<h3>Cancel my account</h3>
+<div class="col-md-12">
+  <h3>Cancel my account</h3>
 
-<p>Unhappy? <%= link_to "Cancel my account", registration_path(resource_name), :data => { :confirm => "Are you sure?" }, :method => :delete %>.</p>
+  <p>Unhappy? <%= link_to "Cancel my account", registration_path(resource_name), :data => { :confirm => "Are you sure?" }, :method => :delete %>.</p>
 
-<%= link_to "Back", :back %>
+  <%= link_to "Back", :back %>
+</div>

--- a/app/views/devise/shared/_links.erb
+++ b/app/views/devise/shared/_links.erb
@@ -1,3 +1,4 @@
+<div class="col-md-12">
 <%- if controller_name != 'sessions' %>
   <%= link_to "Sign in", new_session_path(resource_name) %><br />
 <% end -%>
@@ -23,3 +24,4 @@
     <%= link_to "Sign in with #{provider.to_s.titleize}", omniauth_authorize_path(resource_name, provider) %><br />
   <% end -%>
 <% end -%>
+</div>

--- a/app/views/events/_form.html.erb
+++ b/app/views/events/_form.html.erb
@@ -4,15 +4,19 @@
   <div class="form-inputs">
     <%= f.input :title %>
     <%= f.input :description %>
-    <%= f.input :status, :as => :select, :collection => Event::STATUS_CHOICES  %>
+    <%= f.input :status, :as => :select, :collection => Event::STATUS_CHOICES %>
     <%= f.input :category, :as => :select, :collection => Event::CATEGORY_CHOICES %>
     <div class="training-controls">
       <%= f.association :course, :hint => "If the training is not for certification, do not choose a course" %>
       <%= f.input :instructor %>
     </div>
     <%= f.input :location %>
-    <%= f.input :start_time, :as => :string, :label => "Start Time", :input_html => {:class => "datetimepicker",  :size => 11 }  %>
-    <%= f.input :end_time, :as => :string, :label => "End Time", :input_html => {:class => "datetimepicker", :size => 11 }  %>
+    <%= f.input :start_time, as: :string, label: "Start Time",
+                input_html: { class: "datetimepicker", size: 11,
+                              value: format_datetime_value(f.object.start_time) } %>
+    <%= f.input :end_time, as: :string, label: "End Time",
+                input_html: { class: "datetimepicker", size: 11,
+                              value: format_datetime_value(f.object.end_time) } %>
     <%= f.input :comments %>
   </div>
 

--- a/app/views/inspections/_form.html.erb
+++ b/app/views/inspections/_form.html.erb
@@ -2,8 +2,9 @@
   <%= f.error_notification %>
 
   <div class="form-inputs">
-    <%= f.input :inspection_date, as: :string, input_html: { class: 'datetimepicker', size: 11,
-                                                             value: format_datetime_value(f.object.inspection_date) } %>
+    <%= f.input :inspection_date, as: :string,
+                input_html: { class: 'datetimepicker', size: 11,
+                              value: format_datetime_value(f.object.inspection_date) } %>
     <%= f.input :status, as: :select, collection: Inspection::STATUS_CHOICES, selected: "Incomplete" %>
     <%= f.input :comments %>
   </div>

--- a/app/views/items/_form.html.erb
+++ b/app/views/items/_form.html.erb
@@ -17,9 +17,13 @@
     <%= f.input :po_number %>
     <%= f.input :value, :placeholder => 'Replacement price' %>
     <%= f.input :grant, :placeholder => 'Grant name, if applicable' %>
-    <%= f.input :purchase_date, :as => :string, :input_html => { :class => 'datepicker', :size => 11 }  %>
+    <%= f.input :purchase_date, as: :string,
+                input_html: { class: 'datepicker', size: 11,
+                              value: format_date_value(f.object.purchase_date) } %>
     <%= f.input :purchase_amt %>
-    <%= f.input :sell_date, :as => :string, :input_html => { :class => 'datepicker', :size => 11 }  %>
+    <%= f.input :sell_date, as: :string,
+                input_html: { class: 'datepicker', size: 11,
+                              value: format_date_value(f.object.sell_date) } %>
     <%= f.input :sell_amt %>
     <%= f.file_field :item_image %>
     <%= f.input :comments %>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -6,9 +6,6 @@
       <th>Name</th>
       <th>Model</th>
       <th>Category</th>
-      <th>Serial 1</th>
-      <th>Serial 2</th>
-      <th>Serial 3</th>
       <th>Costs</th>
       <th>Status</th>
       <th></th>
@@ -21,9 +18,6 @@
         <td><%= link_to item.name, item_path(item) %></td>
         <td><%= item.model %></td>
         <td><%= item.category %></td>
-        <td><%= item.serial1 %></td>
-        <td><%= item.serial2 %></td>
-        <td><%= item.serial3 %></td>
         <td><%= number_to_currency item.recent_costs %></td>
         <td>
           <span class="label <%= item_label(item) %>">

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -33,18 +33,6 @@
   <p><b>Item Type:</b> <%= @item.item_type %></p>
 <% end %>
 
-<% if @item.serial1.present? %>
-  <p><b>Serial 1:</b> <%= @item.serial1 %> </p>
-<% end %>
-
-<% if @item.serial2.present? %>
-  <p><b>Serial 2:</b> <%= @item.serial2 %> </p>
-<% end %>
-
-<% if @item.serial3.present? %>
-  <p><b>Serial 3</b> <%= @item.serial3 %></p>
-<% end %>
-
 <% if @item.owner.present? %>
   <p><b>Owner:</b> <%= @item.owner.fullname %></p>
 <% end %>

--- a/app/views/people/_form.html.erb
+++ b/app/views/people/_form.html.erb
@@ -3,12 +3,14 @@
     <%= f.input :firstname, :label => 'First Name' %>
     <%= f.input :lastname, :label => 'Last Name' %>
     <%= f.input :gender, :as => :select, :collection => ['Female', 'Male'] %>
-    <%= f.input :date_of_birth, :as => :string, :placeholder => '12-31-1990', :input_html => { :size => 11 }  %>
-    <%= f.input :zipcode, :input_html => { :size => 10 }  %>
+    <%= f.input :date_of_birth, as: :string, placeholder: '1990-12-31', input_html: { size: 11, value: format_date_value(f.object.date_of_birth) } %>
+    <%= f.input :zipcode, :input_html => { :size => 10 } %>
     <%= f.input :city %>
     <%= f.input :state %>
     <%= f.input :status, :as => :select, :collection => Person::STATUS %>
-    <%= f.input :end_date, :as => :string, :input_html => { :class => 'datepicker', :size => 11 }  %>
+    <%= f.input :end_date, as: :string,
+                input_html: { class: 'datepicker', size: 11,
+                              value: format_date_value(f.object.end_date) } %>
     <%= f.input :department, :as => :select, :collection => Person::DEPARTMENT %>
     <div class="form-horizontal">
       <h2> Phone information </h2>
@@ -45,12 +47,14 @@
     <%= f.input :icsid, :input_html => { :size => 5 } %>
     <%= f.input :title, :as => :select, label: 'Rank', :collection => Person::TITLES %>
     <%= f.association :titles %>
-    <%= f.input :start_date, :as => :string, :input_html => { :class => 'datepicker', :size => 11 }  %>
+    <%= f.input :start_date, as: :string,
+                input_html: { class: 'datepicker', size: 11,
+                              value: format_date_value(f.object.start_date) } %>
     <%= f.input :division1, :as => :select, :label => 'Division', :collection => Person::DIVISION1 %>
     <%= f.input :division2, :as => :select, :label => 'Squad', :collection => Person::DIVISION2 %>
     <h4> Personnel Image </h4>
     <%= @person.portrait %>
     <%= f.file_field :portrait %>
-    <%= f.input :comments, :input_html => { :size => 40}  %>
+    <%= f.input :comments, :input_html => { :size => 40} %>
     <%= f.button :submit %>
 <% end %>

--- a/app/views/repairs/_form.html.erb
+++ b/app/views/repairs/_form.html.erb
@@ -5,8 +5,9 @@
     <%= f.association :item %>
     <%= f.association :person, :label => "Repairer" %>
     <%= f.input :status, :as => :select, :collection => Repair::STATUS_CHOICES %>
-    <%= f.input :service_date, as: :string, input_html: { class: 'datepicker', size: 11,
-                                                          value: format_date_value(f.object.service_date) } %>
+    <%= f.input :service_date, as: :string,
+                input_html: { class: 'datepicker', size: 11,
+                              value: format_date_value(f.object.service_date) } %>
     <%= f.input :description %>
     <%= f.input :cost %>
     <%= f.input :comments %>

--- a/app/views/timecards/_form.html.erb
+++ b/app/views/timecards/_form.html.erb
@@ -10,15 +10,23 @@
     <fieldset>
       <legend>Intention</legend>
       <%= f.input :intention, :as => :select, :collection => Timecard::INTENTION_CHOICES %>
-      <%= f.input :intended_start_time, :as => :string, :input_html => {:class => "datetimepicker",  :size => 11 }  %>
-      <%= f.input :intended_end_time, :as => :string, :input_html => {:class => "datetimepicker", :size => 11 }  %>
+      <%= f.input :intended_start_time, as: :string,
+                  input_html: { class: "datetimepicker", size: 11,
+                                value: format_datetime_value(f.object.intended_start_time) } %>
+      <%= f.input :intended_end_time, as: :string,
+                  input_html: { class: "datetimepicker", size: 11,
+                                value: format_datetime_value(f.object.intended_end_time) } %>
     </fieldset>
     <fieldset>
       <legend>Outcome</legend>
       <%= f.input :outcome, :as => :select, :collection => Timecard::OUTCOME_CHOICES %>
-      <%= f.input :actual_start_time, :as => :string, 
-                  :input_html => {:class => "datetimepicker", :size => 11, :title => "When they actually started to work" }  %>
-      <%= f.input :actual_end_time, :as => :string, :input_html => {:class => "datetimepicker", :size => 11 }  %>
+      <%= f.input :actual_start_time, as: :string,
+                  input_html: { class: "datetimepicker", size: 11,
+                                value: format_datetime_value(f.object.actual_start_time),
+                                title: "When they actually started to work" } %>
+      <%= f.input :actual_end_time, as: :string,
+      input_html: { class: "datetimepicker", size: 11,
+                    value: format_datetime_value(f.object.actual_end_time) } %>
     </fieldset>
   </div>
 

--- a/config/initializers/validators.rb
+++ b/config/initializers/validators.rb
@@ -1,0 +1,17 @@
+# A helper for validating that first_attr_name is before second_attr_name chronologically
+# Unlike many validation methods, this accepts two and only two arguments.
+# Usage within a Model:
+# validates_chronology :start_time, :end_time
+
+ActiveRecord::Base.class_eval do
+  def self.validates_chronology(first_attr_name, second_attr_name)
+    validates_each(first_attr_name) do |record, attr_name, value|
+      first_time = value
+      second_time = record.send(second_attr_name)
+      if first_time.present? and second_time.present? and second_time < first_time
+        record.errors.add(first_attr_name, "must be before '#{second_attr_name}', unless you are the Doctor")
+        record.errors.add(second_attr_name, "must be after '#{first_attr_name}', unless you are the Doctor")
+      end
+    end
+  end
+end

--- a/spec/factories/availabilities.rb
+++ b/spec/factories/availabilities.rb
@@ -3,6 +3,6 @@ FactoryGirl.define do
     start_time Time.now
     end_time 15.hours.from_now
     status "Unavailable"
-    comments "Vacation"
+    description "Vacation"
   end
 end

--- a/spec/features/events_spec.rb
+++ b/spec/features/events_spec.rb
@@ -104,7 +104,7 @@ describe "Events" do
       expect(current_path).to eq(event_path(@event))
     end
     it "hides the course if category isn't training" , js: true,
-        :skip => 'Errors in Javascript ibrary' do
+        :skip => 'Errors in Javascript library' do
       visit new_event_path
       select 'Patrol', :from => 'event_category'
       fill_in "Description", with: "Really Long Text..."  #This ensures the blur event happens

--- a/spec/features/inspection_display_spec.rb
+++ b/spec/features/inspection_display_spec.rb
@@ -13,8 +13,8 @@ describe "Inspection" do
     click_on 'Sign in'
   end
   describe "when not logged in" do
-    let(:an_item)  { FactoryGirl.create(:item) }
-    let(:an_inspection) { FactoryGirl.create(:inspection, item: an_item) }
+    let(:an_item)  { create(:item) }
+    let(:an_inspection) { create(:inspection, item: an_item) }
     it "should not display a listing" do
       click_on 'Sign Out'
       visit inspections_path
@@ -30,8 +30,8 @@ describe "Inspection" do
   end
 
   context "on an item" do
-    let(:an_item)  { FactoryGirl.create(:item) }
-    let(:an_inspection) { FactoryGirl.create(:inspection, item: an_item) }
+    let(:an_item)  { create(:item) }
+    let(:an_inspection) { create(:inspection, item: an_item) }
     it "should show an inspection" do
       visit inspection_path(an_inspection)
       expect(page).to have_content(an_inspection.status)
@@ -39,7 +39,7 @@ describe "Inspection" do
   end
 
   context "from an item" do
-    let!(:item)  { FactoryGirl.create(:item) }
+    let!(:item)  { create(:item) }
     it "should create an inspection for that item" do
       visit item_path(item)
       expect(page).to have_content('Description:')

--- a/spec/models/availability_spec.rb
+++ b/spec/models/availability_spec.rb
@@ -2,4 +2,25 @@ require 'rails_helper'
 
 RSpec.describe Availability, type: :model do
   pending "add some examples to (or delete) #{__FILE__}"
+
+  let(:a_person) { build(:person) }
+
+  describe "creation" do
+    it "has a valid factory" do
+      @availability = build(:availability, person: a_person)
+      expect(@availability).to be_valid
+    end
+  end
+
+  context 'validations' do
+    it { should validate_presence_of(:person) }
+    it { should validate_presence_of(:status) }
+    it { should validate_presence_of(:start_time) }
+    it { should validate_presence_of(:end_time) }
+
+    it "requires end_time to be after start_time" do #chronology
+      @availability = build(:availability, person: a_person, start_time: Time.current, end_time: 2.minutes.ago)
+      expect(@availability).not_to be_valid
+    end
+  end
 end

--- a/spec/models/cert_spec.rb
+++ b/spec/models/cert_spec.rb
@@ -4,11 +4,17 @@ describe Cert do
   let(:evoc_course) { create(:course, term: 100) }
   subject { create :cert, course: evoc_course }
 
-  it 'sets the issued date to today' do
+  it 'sets the issued date to today' do # This is set in the factory
     expect(subject.issued_date).to be == Date.today
   end
 
   it 'sets the expiration date properly' do
     expect(subject.expiration_date).to be == Date.today + evoc_course.term.to_i.months
   end
+
+  it "requires expiration_date to be after issued_date" do #chronology
+    @cert = build(:cert, course: evoc_course, issued_date: 2.days.from_now, expiration_date: 2.days.ago)
+    expect(@cert).not_to be_valid
+  end
+
 end

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -7,8 +7,8 @@ describe Event do
   it "is invalid without a title" do
     expect(build(:event, title: nil)).not_to be_valid
   end
-  
-  it "is invalid if end date is before start date" do
+
+  it "is invalid if end_time is before start_time" do #chronology
     expect(build(:event, start_time: Time.current, end_time: 10.days.ago)).not_to be_valid
   end
 

--- a/spec/models/inspection_spec.rb
+++ b/spec/models/inspection_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe Inspection do
-  let(:an_item)  { FactoryGirl.create(:item) }
+  let(:an_item)  { create(:item) }
   it "has a valid factory" do
     expect(create(:inspection, item: an_item)).to be_valid
   end

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -20,6 +20,12 @@ describe Person do
         end
       end
     end
+
+    it "requires end_date to be after start_date" do #chronology
+      @person = build(:person, start_date: 2.days.from_now, end_date: 2.days.ago)
+      expect(@person).not_to be_valid
+    end
+
   end
 
   describe 'skills' do

--- a/spec/models/timecard_spec.rb
+++ b/spec/models/timecard_spec.rb
@@ -16,8 +16,12 @@ describe Timecard do
       @timecard = build(:timecard, person: nil)
       expect(@timecard).not_to be_valid
     end
-    it "requires an intended_end_time after intended_start_time" do
+    it "requires intended_end_time to be after intended_start_time" do #chronology
       @timecard = build(:timecard, intended_start_time: Time.current, intended_end_time: 2.minutes.ago)
+      expect(@timecard).not_to be_valid
+    end
+    it "requires actual_end_time to be after actual_start_time" do #chronology
+      @timecard = build(:timecard, actual_start_time: Time.current, actual_end_time: 2.minutes.ago)
       expect(@timecard).not_to be_valid
     end
     it "calculates an actual duration" do
@@ -33,8 +37,8 @@ describe Timecard do
       expect(@timecard.intended_duration).to eq(1.25)
     end
 
-    it "finds the existing timecard if it's a duplicate" do
-      skip "Find duplicate timecards is too simple, but not needed until people are scanning in"
+    it "finds the existing timecard if it's a duplicate",
+       skip: "Find duplicate timecards is too simple, but not needed until people are scanning in" do
       @event = create(:event)
       @person = create(:person)
       @original_timecard = create(:timecard, event: @event, person: @person,


### PR DESCRIPTION
Addresses #140, #142, #133, and #144.  Factored out of the work I'd begun on tasks.

The most interesting piece is in `config/initializers/validators.rb`, where the validator `validates_chronology` is defined, to be available in all of our models.  It is used as follows:
`validates_chronology :start_time, :end_time`

I've used it in models that seem to need it, and confirmed that they passes existing tests for chronology, and added tests to models that hadn't tested this.

`item.rb` has a couple of fields that may or may not need this validation.  They are there, but commented, and tests have not been added.

I've also fixed datepicker/datetimepicker's functionality in a number of forms (the problem manifested as corruption of a field's contents when editing a form with a saved date/datetime value) .

I've fixed a few cosmetic issues I've discovered.
