### PR TITLE
display_cleanup - followup to previous PRs and preliminary to upcoming PR

### DIFF
--- a/app/assets/javascripts/items.js.coffee
+++ b/app/assets/javascripts/items.js.coffee
@@ -9,10 +9,9 @@ jQuery ->
   $('#items').dataTable
     columnDefs: [
                   ## https://datatables.net/extensions/responsive/priority
-                  { responsivePriority: 1, targets: [0, 1, 2, 3, 8, 9 ] },
-                  { responsivePriority: 2, targets: 7 },
-                  { responsivePriority: 3, targets: 4 },
-                  { responsivePriority: 4, targets: 5 },
-                  { responsivePriority: 5, targets: 6 },
-                  { orderable: false, targets: 9 },
+                  { responsivePriority: 1, targets: [0, 1, 5, 6 ] },
+                  { responsivePriority: 2, targets: 4 },
+                  { responsivePriority: 3, targets: 2 },
+                  { responsivePriority: 4, targets: 3 },
+                  { orderable: false, targets: -1 },
                 ]

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -92,11 +92,13 @@ module ApplicationHelper
   # label.  For anything more precise, a custom helper should be
   # used (as in items_helper.rb)
   def success_or_warning_label(str, success_str)
-    if str == success_str
-      return 'label-success'
-    else
-      return 'label-warning'
-    end
+    content_tag(:span, str, class: success_or_warning_label_class(str, success_str))
+  end
+
+  # This is a general helper to provide a simple success tag when appropriate.
+  # This should be called with raw or with <%==
+  def success_class_if_match(str, success_str)
+    return 'class="success"' if str == success_str
   end
 
   # This is for providing a date for a form in an order that Rails can understand.
@@ -110,5 +112,14 @@ module ApplicationHelper
   def format_datetime_value(datetime)
     datetime.strftime("%Y-%m-%d %H:%M") if datetime
   end
+
+  private
+    def success_or_warning_label_class(str, success_str)
+      if str == success_str
+        return 'label label-success'
+      else
+        return 'label label-warning'
+      end
+    end
 
 end

--- a/app/helpers/inspections_helper.rb
+++ b/app/helpers/inspections_helper.rb
@@ -1,17 +1,22 @@
 module InspectionsHelper
-  def inspection_label(inspection)
-    # The options are found in app/models/inspection.rb: STATUS_CHOICES
-    return nil if inspection.status.blank?
-    case inspection.status
-    when 'Complete - Passed'
-      return 'label-success'
-    when 'Incomplete'
-      return 'label-warning'
-    when 'Complete - Failed'
-      return 'label-danger'
-    else
-      # This should only happen if another status is added.
-      return 'label-default'
-    end
+  def inspection_status_label(inspection)
+    content_tag(:span, inspection.status, class: inspection_label_class(inspection))
   end
+
+  private
+    def inspection_label_class(inspection)
+      # The options are found in app/models/inspection.rb: STATUS_CHOICES
+      return nil if inspection.status.blank?
+      case inspection.status
+      when 'Complete - Passed'
+        return 'label label-success'
+      when 'Incomplete'
+        return 'label label-warning'
+      when 'Complete - Failed'
+        return 'label label-danger'
+      else
+        # This should only happen if another status is added.
+        return 'label label-default'
+      end
+    end
 end

--- a/app/helpers/items_helper.rb
+++ b/app/helpers/items_helper.rb
@@ -1,18 +1,6 @@
 module ItemsHelper
-  def item_label(item)
-    # The options are found in app/models/item.rb: STATUS_CHOICES
-    return nil if item.status.blank?
-    case item.status
-    when 'Available'
-      return 'label-success'
-    when 'In Service', 'In Service - Degraded'
-      return 'label-warning'
-    when 'Out of Service', 'Sold', 'Destroyed'
-      return 'label-danger'
-    else
-      # This should only happen if another status is added.
-      return 'label-default'
-    end
+  def item_status_label(item)
+    content_tag(:span, item.status, class: item_label_class(item))
   end
 
   def edit_item_button
@@ -33,4 +21,21 @@ module ItemsHelper
                    new_item_inspection_path(@item),
                    class: 'btn btn-block btn-primary'
   end
+
+  private
+    def item_label_class(item)
+      # The options are found in app/models/item.rb: STATUS_CHOICES
+      return nil if item.status.blank?
+      case item.status
+      when 'Available'
+        return 'label label-success'
+      when 'In Service', 'In Service - Degraded'
+        return 'label label-warning'
+      when 'Out of Service', 'Sold', 'Destroyed'
+        return 'label label-danger'
+      else
+        # This should only happen if another status is added.
+        return 'label label-default'
+      end
+    end
 end

--- a/app/views/availabilities/_availabilities_table.html.erb
+++ b/app/views/availabilities/_availabilities_table.html.erb
@@ -1,4 +1,4 @@
-<table id="availabilities" class="generic_datatable datatable display table table-striped table-bordered">
+<table id="availabilities" class="generic_datatable table table-striped table-bordered">
   <caption><h3><%= "Availability" %></h3></caption>
   <thead>
     <tr>
@@ -13,7 +13,7 @@
   </thead>
   <tbody>
     <% availabilities.each do |availability| %>
-      <tr>
+      <tr <%== success_class_if_match(availability.status, 'Available') %>>
         <td><%= availability.status %></td>
         <td><%= availability.person.icsid %></td>
         <td><%= link_to availability.person.fullname, availability_path(availability) %></td>

--- a/app/views/availabilities/_availabilities_table_for_people.html.erb
+++ b/app/views/availabilities/_availabilities_table_for_people.html.erb
@@ -1,4 +1,4 @@
-<table id="availabilities" class="generic_datatable datatable display table table-striped table-bordered">
+<table id="availabilities" class="generic_datatable table table-striped table-bordered">
   <thead>
     <tr>
       <th>Status</th>
@@ -9,7 +9,7 @@
   </thead>
   <tbody>
     <% availabilities.each do |availability| %>
-      <tr>
+      <tr <%== success_class_if_match(availability.status, 'Available') %>>
         <td><%= availability.status %></td>
         <td><time><%= availability.start_time %></time></td>
         <td><%= availability.end_time %></td>

--- a/app/views/availabilities/index.html.erb
+++ b/app/views/availabilities/index.html.erb
@@ -1,6 +1,6 @@
 <h1>Listing Availabilities</h1>
 
-<table id="availabilities" class="datatable display table table-striped table-bordered" >
+<table id="availabilities" class="generic_datatable table table-striped table-bordered">
   <thead>
     <tr>
       <th>Person</th>
@@ -14,7 +14,7 @@
 
   <tbody>
     <% @availabilities.each do |availability| %>
-      <tr>
+      <tr <%== success_class_if_match(availability.status, 'Available') %>>
         <td><%= link_to availability.person.fullname, availability_path(availability) %></td>
         <td><%= availability.start_time.to_s(:short) %></td>
         <td><%= availability.end_time.to_s(:short) %></td>

--- a/app/views/courses/show.html.erb
+++ b/app/views/courses/show.html.erb
@@ -6,10 +6,7 @@
 <% end %>
 
 <p>
-  <b>Status:</b>
-  <span class="label <%= success_or_warning_label(@course.status, 'Active') %>">
-    <%= @course.status %>
-  </span>
+  <b>Status:</b> <%= success_or_warning_label(@course.status, 'Active') %>
 </p>
 
 <p><b>Description:</b> <%= @course.description %></p>

--- a/app/views/inspections/_inspections_table.erb
+++ b/app/views/inspections/_inspections_table.erb
@@ -12,7 +12,7 @@
     <% @inspections.each do |inspection| %>
       <tr>
         <td><%= link_to format_datetime_value(inspection.inspection_date), inspection %></td>
-        <td><span class="label <%= inspection_label(inspection) %>"><%= inspection.status %></span></td>
+        <td><%= inspection_status_label(inspection) %></td>
         <td><%= truncate(inspection.comments) %></td>
         <td><%= table_button_link 'Edit', edit_inspection_path(inspection) if can? :edit, inspection %></td>
       </tr>

--- a/app/views/inspections/index.html.erb
+++ b/app/views/inspections/index.html.erb
@@ -19,7 +19,7 @@
       <tr>
         <td><%= link_to inspection.item&.name, inspection.item %></td>
         <td><%= link_to format_datetime_value(inspection.inspection_date), inspection %></td>
-        <td><span class="label <%= inspection_label(inspection) %>"><%= inspection.status %></span></td>
+        <td><%= inspection_status_label(inspection) %></td>
         <td><%= truncate(inspection.comments) %></td>
         <td><%= table_button_link 'Edit', edit_inspection_path(inspection) if can? :edit, inspection %></td>
         <td><%= table_button_link 'Destroy', inspection, method: :delete if can? :destroy, inspection %></td>

--- a/app/views/inspections/show.html.erb
+++ b/app/views/inspections/show.html.erb
@@ -8,11 +8,7 @@
 
 Inspection of <%= link_to @inspection.item.name, item_path(@inspection.item) %>
 on <%= format_date_value(@inspection.inspection_date) %>.
-<p>Status:
-  <span class="label <%= inspection_label(@inspection) %>">
-    <%= @inspection.status %>
-  </span>
-</p>
+<p>Status: <%= inspection_status_label(@inspection) %></p>
 
 <% if @inspection.comments.present? %>
   <p>Comments: <%= @inspection.comments %></p>

--- a/app/views/items/_form.html.erb
+++ b/app/views/items/_form.html.erb
@@ -1,4 +1,4 @@
-<%= simple_form_for @item, :html => {:multipart => true}  do |f| %>
+<%= simple_form_for @item, :html => {:multipart => true} do |f| %>
   <%= f.error_notification %>
 
   <div class="form-inputs">

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -19,11 +19,7 @@
         <td><%= item.model %></td>
         <td><%= item.category %></td>
         <td><%= number_to_currency item.recent_costs %></td>
-        <td>
-          <span class="label <%= item_label(item) %>">
-            <%= item.status %>
-          </span>
-        </td>
+        <td><%= item_status_label(item) %></td>
         <td><%= table_button_link 'Edit', edit_item_path(item) unless cannot? :edit, item %></td>
       </tr>
     <% end %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -7,9 +7,7 @@
 
 <h3>
   <% if @item.status.present? %>
-  <span class="label <%= item_label(@item) %>">
-    <%= @item.status %>
-  </span> &nbsp;
+    <%= item_status_label(@item) %> &nbsp;
   <% end %>
   <%= @item.name %>
   <% if @item.brand.present? || @item.model.present? %>

--- a/app/views/people/_form.html.erb
+++ b/app/views/people/_form.html.erb
@@ -1,5 +1,6 @@
 <%= simple_form_for @person, :html => {:multipart => true} do |f| %>
     <%= f.error_notification %>
+
     <%= f.input :firstname, :label => 'First Name' %>
     <%= f.input :lastname, :label => 'Last Name' %>
     <%= f.input :gender, :as => :select, :collection => ['Female', 'Male'] %>
@@ -12,9 +13,9 @@
                 input_html: { class: 'datepicker', size: 11,
                               value: format_date_value(f.object.end_date) } %>
     <%= f.input :department, :as => :select, :collection => Person::DEPARTMENT %>
-    <div class="form-horizontal">
+
       <h2> Phone information </h2>
-      <%= f.simple_fields_for :phones do |c| %>
+      <%= f.simple_fields_for :phones, wrapper: :horizontal_input_group do |c| %>
         <fieldset>
           <%= c.input :id, :as => :hidden %>
           <%= c.input :category, :as => :select, :collection => Channel::CATEGORIES %>
@@ -23,16 +24,15 @@
           <%= c.input :status, :as => :select, :collection => Channel::STATUSES %>
           <%= c.input :usage, :as => :select, :collection => Channel::USAGES %>
           <%= c.input :carrier, :as => :select, :collection => Phone::CARRIERS %>
-          <%= c.input :sms_available, as: :boolean %>
           <%= c.input :priority, :as => :select, :collection => Phone::PRIORITIES %>
           <%= c.input :channel_type, as: :select, collection: Phone::TYPES %>
+          <%= c.input :sms_available, as: :boolean %>
         </fieldset>
         <hr />
       <% end %>
-    </div>
-    <div class="form-horizontal">
+
       <h2> Email information </h2>
-      <%= f.simple_fields_for :emails do |c| %>
+      <%= f.simple_fields_for :emails, wrapper: :horizontal_input_group do |c| %>
         <fieldset>
           <%= c.input :id, :as => :hidden %>
           <%= c.input :category, :as => :select, :collection => Channel::CATEGORIES %>
@@ -43,7 +43,7 @@
         </fieldset>
         <hr />
       <% end %>
-    </div>
+
     <%= f.input :icsid, :input_html => { :size => 5 } %>
     <%= f.input :title, :as => :select, label: 'Rank', :collection => Person::TITLES %>
     <%= f.association :titles %>

--- a/app/views/people/_people_table.html.erb
+++ b/app/views/people/_people_table.html.erb
@@ -1,4 +1,4 @@
-<table id="people" class="generic_datatable datatable display table table-striped table-bordered">
+<table id="people" class="generic_datatable table table-striped table-bordered">
   <caption><h3><%= title %></h3></caption>
   <thead>
     <tr>

--- a/app/views/people/show.html.erb
+++ b/app/views/people/show.html.erb
@@ -14,10 +14,7 @@
 <% end %>
 
 <p>
-  <b>Status:</b>
-  <span class="label <%= success_or_warning_label(@person.status, 'Active') %>">
-    <%= @person.status %>
-  </span>
+  <b>Status:</b> <%= success_or_warning_label(@person.status, 'Active') %>
 </p>
 
 <div id="channels">

--- a/app/views/titles/show.html.erb
+++ b/app/views/titles/show.html.erb
@@ -25,7 +25,7 @@
   <%= @title.comments %>
 </p>
 
-<table class="table table-striped table-bordered">
+<table class="generic_datatable table table-striped table-bordered">
   <thead>
     <tr>
       <th>People Who Seek This Title (<%= @title.people.active.uniq.count %>)</th>

--- a/config/initializers/simple_form_bootstrap.rb
+++ b/config/initializers/simple_form_bootstrap.rb
@@ -4,7 +4,7 @@ SimpleForm.setup do |config|
   config.button_class = 'btn btn-primary'
   config.boolean_label_class = nil
 
-  config.wrappers :vertical_form, tag: 'div', class: 'form-group ', error_class: 'has-error' do |b|
+  config.wrappers :vertical_form, tag: 'div', class: 'form-group', error_class: 'has-error' do |b|
     b.use :html5
     b.use :placeholder
     b.optional :maxlength
@@ -132,6 +132,39 @@ SimpleForm.setup do |config|
       ba.use :hint,  wrap_with: { tag: 'p', class: 'help-block' }
     end
   end
+
+  # from: https://github.com/plataformatec/simple_form/wiki/How-to-use-Bootstrap-3-input-group-in-Simple-Form
+  # File here config/initializers/simple_form_bootstrap.rb
+  SimpleForm.setup do |config|
+    config.wrappers :vertical_input_group, tag: 'div', class: 'form-group', error_class: 'has-error' do |b|
+      b.use :html5
+      b.use :placeholder
+      b.use :label, class: 'control-label'
+
+      b.wrapper tag: 'div' do |ba|
+        ba.wrapper tag: 'div', class: 'input-group col-sm-12' do |append|
+          append.use :input, class: 'form-control'
+        end
+        ba.use :error, wrap_with: { tag: 'span', class: 'help-block' }
+        ba.use :hint,  wrap_with: { tag: 'p', class: 'help-block' }
+      end
+    end
+
+    config.wrappers :horizontal_input_group, tag: 'div', class: 'form-group', error_class: 'has-error' do |b|
+      b.use :html5
+      b.use :placeholder
+      b.use :label, class: 'col-sm-3 control-label'
+
+      b.wrapper tag: 'div', class: 'col-sm-9' do |ba|
+        ba.wrapper tag: 'div', class: 'input-group col-sm-12' do |append|
+          append.use :input, class: 'form-control'
+        end
+        ba.use :error, wrap_with: { tag: 'span', class: 'help-block' }
+        ba.use :hint,  wrap_with: { tag: 'p', class: 'help-block' }
+      end
+    end
+  end
+
   # Wrappers for forms and inputs using the Bootstrap toolkit.
   # Check the Bootstrap docs (http://getbootstrap.com)
   # to learn about the different styles for forms and inputs,
@@ -140,8 +173,8 @@ SimpleForm.setup do |config|
   config.wrapper_mappings = {
     check_boxes: :vertical_radio_and_checkboxes,
     radio_buttons: :vertical_radio_and_checkboxes,
-    file: :vertical_file_input,
-    boolean: :vertical_boolean,
+    file: :horizontal_file_input,
+    boolean: :horizontal_boolean,
     datetime: :multi_select,
     date: :multi_select,
     time: :multi_select

--- a/config/initializers/validators.rb
+++ b/config/initializers/validators.rb
@@ -9,8 +9,8 @@ ActiveRecord::Base.class_eval do
       first_time = value
       second_time = record.send(second_attr_name)
       if first_time.present? and second_time.present? and second_time < first_time
-        record.errors.add(first_attr_name, "must be before '#{second_attr_name}', unless you are the Doctor")
-        record.errors.add(second_attr_name, "must be after '#{first_attr_name}', unless you are the Doctor")
+        record.errors.add(first_attr_name, "must be before '#{human_attribute_name(second_attr_name)}', unless you are the Doctor")
+        record.errors.add(second_attr_name, "must be after '#{human_attribute_name(first_attr_name)}', unless you are the Doctor")
       end
     end
   end


### PR DESCRIPTION
display_cleanup - followup to previous PRs and preliminary to upcoming PR

Several small improvements and cleanups:
1) Fix datatable initialization in `items.js.coffee` which broke after removing columns.
2) Improve label helpers; apply to code base (e.g., `inspection_status_label`).
3) Highlight a row based on status (`success_class_if_match`), e.g.,
`<tr <%== success_class_if_match(availability.status, 'Available') %>>...</tr>`
4) Fix a few classes for datatables.
5) Improve styling of `people_form.html.erb` (somewhat broken since Bootstrap 3).
6) Improve error message for the `validates_chronology` helper.
