### PR TITLE
Use #maintain_test_schema!

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -21,6 +21,7 @@ require 'rspec/rails'
 # require only the support files necessary.
 #
 # Dir[Rails.root.join('spec/support/**/*.rb')].each { |f| require f }
+ActiveRecord::Migration.maintain_test_schema!
 
 RSpec.configure do |config|
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures


### PR DESCRIPTION
Resolves: https://github.com/ReadyResponder/ReadyResponder/issues/126

Changes:

Include `#maintain_test_schema!` in `rails_helper.rb` to provide a message when the test schema also has pending migrations. 

```
➜  ReadyResponder git:(development) ✗ bundle exec rspec
/Users/charleschanlee/.rvm/gems/ruby-2.3.0/gems/activerecord-4.2.7/lib/active_record/migration.rb:392:in `check_pending!':  (ActiveRecord::PendingMigrationError)

Migrations are pending. To resolve this issue, run:

        bin/rake db:migrate RAILS_ENV=test
```
