### PR TITLE
remove serial[123] from items

### DIFF
--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -3,7 +3,6 @@ class Item < ActiveRecord::Base
                   :model, :brand, :name, :owner_id, :po_number,
                   :value, :grant, :purchase_amt, :purchase_date,
                   :sell_amt, :sell_date, :stock_number,
-                  :serial1, :serial2, :serial3,
                   :source, :status, :comments, :item_image,
                   :department_id, :resource_type_id, :item_type_id,
                   :unique_ids_attributes

--- a/db/migrate/20161005171954_remove_serial_numbers_from_items.rb
+++ b/db/migrate/20161005171954_remove_serial_numbers_from_items.rb
@@ -1,0 +1,7 @@
+class RemoveSerialNumbersFromItems < ActiveRecord::Migration
+  def change
+    remove_column :items, :serial1, :integer
+    remove_column :items, :serial2, :integer
+    remove_column :items, :serial3, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161003170847) do
+ActiveRecord::Schema.define(version: 20161005171954) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -182,7 +182,6 @@ ActiveRecord::Schema.define(version: 20161003170847) do
     t.string   "source"
     t.string   "category"
     t.string   "model"
-    t.string   "serial1"
     t.date     "purchase_date"
     t.float    "purchase_amt"
     t.date     "sell_date"
@@ -190,14 +189,12 @@ ActiveRecord::Schema.define(version: 20161003170847) do
     t.string   "status"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.string   "serial2"
     t.string   "grant"
     t.date     "grantstart"
     t.date     "grantexpiration"
     t.string   "icsid"
     t.string   "po_number"
     t.decimal  "value",            precision: 8, scale: 2
-    t.string   "serial3"
     t.string   "brand"
     t.string   "stock_number"
     t.text     "comments"

--- a/spec/factories/item.rb
+++ b/spec/factories/item.rb
@@ -7,7 +7,6 @@ FactoryGirl.define do
     source "Stoneham Ford"
     category "Vehicle"
     model "F-150"
-    serial1 "VIN123456789"
     purchase_date "2010-12-14"
     purchase_amt ""
     status "Available"


### PR DESCRIPTION
Removes the three serial number fields from the Item model.  Addresses Issue #133.
