### PR TITLE
LIMS -> ReadyResponder in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# LIMS3
+# ReadyResponder
+
+#### Project Build Status: &nbsp; [![Build Status](https://api.travis-ci.org/ReadyResponder/ReadyResponder.svg?branch=development)](https://travis-ci.org/ReadyResponder/ReadyResponder)
 
 This application aids emergency management and other agencies in managing both their personnel and their equipment.
 
@@ -14,11 +16,11 @@ Features:
 
 ## Getting Started
 
-This is a Rails project that is configured to run on Ruby 2, and on a Postgres database.  So, the things you'll need to install before running LIMS locally are Ruby, the `bundler` gem, and Postgres version 9.
+This is a Rails project that is configured to run on Ruby 2, and on a Postgres database.  So, the things you'll need to install before running ReadyResponder locally are Ruby, the `bundler` gem, and Postgres version 9.
 
 1. Ruby: There's a detailed list of options for installing Ruby on the [official Ruby website](https://www.ruby-lang.org/en/documentation/installation/).
   * [RVM](http://rvm.io/), [rbenv](https://github.com/rbenv/rbenv#readme), and [chruby](https://github.com/postmodern/chruby#readme) are common ruby installation managers for Macs & Linux.
-  * The exact version of Ruby that LIMS is using is specified in the [.ruby-version](.ruby-version) file.
+  * The exact version of Ruby that ReadyResponder is using is specified in the [.ruby-version](.ruby-version) file.
 1. Bundler: `gem install bundler`
 1. Postgres
   * If you have `homebrew` on a Mac, you can run `brew install postgres`.
@@ -26,9 +28,9 @@ This is a Rails project that is configured to run on Ruby 2, and on a Postgres d
 
 *Feel free to ask for help!*
 
-#### Contributing to LIMS: Coding :smiley:
+#### Contributing to ReadyResponder: Coding :smiley:
 
-One more thing to install: The testing framework requires the [PhantomJS](http://phantomjs.org) library.  In order to code in LIMS, you'll need to install PhantomJS separately (see below).
+One more thing to install: The testing framework requires the [PhantomJS](http://phantomjs.org) library.  In order to code in ReadyResponder, you'll need to install PhantomJS separately (see below).
 
 Then get the project code locally and set it up:
 
@@ -41,7 +43,7 @@ Then get the project code locally and set it up:
 
 At this point you should be able to run the rails server via `bundle exec rails s`, the rails console via `bundle exec rails c`, and the tests via `bundle exec rspec spec/`
 
-Note: You can use the UI to create a user and sign in, but the UI doesn't allow creation of an admin user.  To use all the features of LIMS in the browser, you will need to enable admin privileges for your local user in the rails console after signing up via the UI:
+Note: You can use the UI to create a user and sign in, but the UI doesn't allow creation of an admin user.  To use all the features of ReadyResponder in the browser, you will need to enable admin privileges for your local user in the rails console after signing up via the UI:
 
 `User.first.roles << Role.where(name: "Manager").first_or_create`
 
@@ -58,14 +60,12 @@ brew install phantomjs
 sudo apt-get install phantomjs
 ```
 
-#### Project Build Status: &nbsp; [![Build Status](https://api.travis-ci.org/ReadyResponder/ReadyResponder.svg?branch=development)](https://travis-ci.org/ReadyResponder/ReadyResponder)
-
 ## More information
 
 See [the wiki](https://github.com/ReadyResponder/ReadyResponder/wiki)!
 
-#### Contributing to LIMS: Community Expectations :raised_hands:
+#### Contributing to ReadyResponder: Community Expectations :raised_hands:
 
-We have a [Code of Conduct](CODE_OF_CONDUCT.md) to set clear expectations for community participation. We want participating in LIMS to be safe, fun, and respectful. We've adopted the ["Contributor Covenant"](http://contributor-covenant.org/) model for our code of conduct, which is the same model that [the Rails project itself](http://rubyonrails.org/conduct/) uses. (Other projects that use a Code of Conduct of this type include [RSpec](https://github.com/rspec/rspec/blob/master/code_of_conduct.md), [Jenkins](https://jenkins-ci.org/conduct/), and [RubyGems](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).)
+We have a [Code of Conduct](CODE_OF_CONDUCT.md) to set clear expectations for community participation. We want participating in ReadyResponder to be safe, fun, and respectful. We've adopted the ["Contributor Covenant"](http://contributor-covenant.org/) model for our code of conduct, which is the same model that [the Rails project itself](http://rubyonrails.org/conduct/) uses. (Other projects that use a Code of Conduct of this type include [RSpec](https://github.com/rspec/rspec/blob/master/code_of_conduct.md), [Jenkins](https://jenkins-ci.org/conduct/), and [RubyGems](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).)
 
 Please read the [Code of Conduct](CODE_OF_CONDUCT.md). By participating in this project you agree to abide by its terms.


### PR DESCRIPTION
Also moved the Build status to just below the top of the README.
Knowing that the project has tests and is building successfully is
a really big deal for potential developers.
