### PR TITLE
fix people redirects

### DIFF
--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -10,7 +10,7 @@ class Ability
     elsif roles.include? "Manager"
       can :manage, :all
     elsif roles.include? "Editor"
-      can [:read, :update, :create, :edit, :police, :cert, :applicants, :prospects, :other, :inactive, :leave, :declined], Person
+      can [:read, :update, :create, :edit, :police, :cert, :applicants, :prospects, :other, :inactive, :leave, :declined, :everybody], Person
       can [:read, :update, :create, :edit], Timecard
       can [:read, :update, :create, :edit], Channel
       can [:read, :update, :create, :edit], Availability

--- a/spec/features/person_creation_spec.rb
+++ b/spec/features/person_creation_spec.rb
@@ -1,0 +1,66 @@
+require 'rails_helper'
+
+RSpec.feature "Users can create new people" do
+  before do
+    somebody = create(:user)
+    r = create(:role, name: 'Editor')
+    somebody.roles << r
+    visit new_user_session_path
+    fill_in 'user_email', :with => somebody.email
+    fill_in 'user_password', :with => somebody.password
+    click_on 'Sign in'
+  end
+
+  scenario "from the home page" do
+    visit root_path
+    click_link "People"
+    click_link "New Person"
+    fill_in "First Name", with: "John"
+    fill_in "Last Name", with: "Doe"
+    fill_in "Date of birth", with: "1990-05-13"
+    select "Active", from: "person_status" #"Status" also matches Channel status
+    click_button "Create Person"
+    expect(page).to have_content "Person was successfully created."
+    expect(current_path).to eq root_path
+  end
+
+  scenario "from the police people page" do
+    visit police_people_path
+    click_link "People"
+    click_link "New Person"
+    fill_in "First Name", with: "John"
+    fill_in "Last Name", with: "Doe"
+    fill_in "Date of birth", with: "1990-05-13"
+    select "Active", from: "person_status" #"Status" also matches Channel status
+    click_button "Create Person"
+    expect(page).to have_content "Person was successfully created."
+    expect(current_path).to eq police_people_path
+  end
+
+  scenario "from the CERT people page" do
+    visit cert_people_path
+    click_link "People"
+    click_link "New Person"
+    fill_in "First Name", with: "John"
+    fill_in "Last Name", with: "Doe"
+    fill_in "Date of birth", with: "1990-05-13"
+    select "Active", from: "person_status" #"Status" also matches Channel status
+    click_button "Create Person"
+    expect(page).to have_content "Person was successfully created."
+    expect(current_path).to eq cert_people_path
+  end
+
+  scenario "from the everybody people page" do
+    visit everybody_people_path
+    click_link "People"
+    click_link "New Person"
+    fill_in "First Name", with: "John"
+    fill_in "Last Name", with: "Doe"
+    fill_in "Date of birth", with: "1990-05-13"
+    select "Active", from: "person_status" #"Status" also matches Channel status
+    click_button "Create Person"
+    expect(page).to have_content "Person was successfully created."
+    expect(current_path).to eq everybody_people_path
+  end
+
+end


### PR DESCRIPTION
Addreses issue #170 and the remainder of issue #123.

After creating/editing a person, redirect to the page one started on before creating/editing.
If one starts from the Police page, one will be returned there.  If one starts from the CERT page, one will be returned there. This can be modified to redirect elsewhere (such as the person, or the person's department list, or some other page), but the capability is now there.

Note that I added :everybody to the 'Editor' role in `app/model/ability.rb`.

Also includes a basic test.
