### PR TITLE
use sign_in_as helper ; small spec cleanups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,7 +19,8 @@
 *.kate-swp
 /public/uploads
 
-#Ignore database settings
+# Ignore database settings
 /config/database.yml
 
-spec/examples.txt
+# Ignore rspec profiling data
+/spec/examples.txt

--- a/spec/features/authorization_cert_spec.rb
+++ b/spec/features/authorization_cert_spec.rb
@@ -1,17 +1,9 @@
 require 'rails_helper'
-      #save_and_open_page
+
 RSpec.describe "a user" do
   describe "in the reader role" do
-    before (:each) do
-      person = create(:person, lastname: 'YesDoe')
-      somebody = create(:user)
-      r = create(:role, name: 'Reader')
-      somebody.roles << r
-      visit new_user_session_path
-      fill_in 'user_email', :with => somebody.email
-      fill_in 'user_password', :with => somebody.password
-      click_on 'Sign in'
-    end
+    before (:each) { sign_in_as('Reader') }
+
     it "cannot edit certs" do
       acert = create(:cert)
       visit certs_path

--- a/spec/features/authorization_editor_spec.rb
+++ b/spec/features/authorization_editor_spec.rb
@@ -1,16 +1,13 @@
 require 'rails_helper'
-      #save_and_open_page
+
 RSpec.describe "a user" do
+  before(:each) do
+    @person = create(:person)
+  end
+
   describe "in the reader role" do
-    before (:each) do
-      @person = create(:person)
-      somebody = create(:user)
-      somebody.roles << create(:role, name: 'Reader')
-      visit new_user_session_path
-      fill_in 'user_email', :with => somebody.email
-      fill_in 'user_password', :with => somebody.password
-      click_on 'Sign in'
-    end
+    before (:each) { sign_in_as('Reader') }
+
     it "cannot edit people" do
       visit edit_person_path(@person)
       expect(page).to have_content("Access Denied")
@@ -35,16 +32,10 @@ RSpec.describe "a user" do
       expect(page).not_to have_content(@person_inactive.lastname)
     end
   end
+
   describe "in the editor role" do
-    before (:each) do
-      @person = create(:person)
-      somebody = create(:user)
-      somebody.roles << create(:role, name: 'Editor')
-      visit new_user_session_path
-      fill_in 'user_email', :with => somebody.email
-      fill_in 'user_password', :with => somebody.password
-      click_on 'Sign in'
-    end
+    before (:each) { sign_in_as('Editor') }
+
     it "can edit people" do
       visit people_path
       expect(page).to have_content('Edit') #Need to scope this, or it will fail on Edith

--- a/spec/features/authorization_guest_spec.rb
+++ b/spec/features/authorization_guest_spec.rb
@@ -1,25 +1,24 @@
 require 'rails_helper'
-      #save_and_open_page
+
 RSpec.describe "a user" do
   describe "without a role" do
     before (:each) do
       @person = create(:person)
-      somebody = create(:user)
-      visit new_user_session_path
-      fill_in 'user_email', :with => somebody.email
-      fill_in 'user_password', :with => somebody.password
-      click_on 'Sign in'
+      sign_in_as(nil) # no role
     end
+
     it "cannot view people" do
       visit people_path
+      expect(page).to have_content("Access Denied")
       expect(page).not_to have_content('Edit') #Need to scope this, or it will fail on Edith
       expect(page).not_to have_content('New')
       expect(page).not_to have_content(@person.lastname)
-      expect(page).to have_content("Access Denied")
-      
+
       visit person_path(@person)
+      expect(page).to have_content("Access Denied")
       expect(page).not_to have_content('Edit')
       expect(page).not_to have_content(@person.lastname)
+
       visit edit_person_path(@person)
       expect(page).to have_content("Access Denied")
     end

--- a/spec/features/authorization_reader_spec.rb
+++ b/spec/features/authorization_reader_spec.rb
@@ -1,16 +1,12 @@
 require 'rails_helper'
-      #save_and_open_page
+
 RSpec.describe "a user" do
   describe "in the reader role" do
     before (:each) do
       @person = create(:person)
-      somebody = create(:user)
-      somebody.roles << create(:role, name: 'Reader')
-      visit new_user_session_path
-      fill_in 'user_email', :with => somebody.email
-      fill_in 'user_password', :with => somebody.password
-      click_on 'Sign in'
+      sign_in_as('Reader')
     end
+
     it "cannot edit people" do
       visit edit_person_path(@person)
       expect(page).to have_content("Access Denied")

--- a/spec/features/authorization_skill_spec.rb
+++ b/spec/features/authorization_skill_spec.rb
@@ -6,14 +6,17 @@ RSpec.describe "a user" do
 
     it "cannot view skills" do
       skill = create(:skill)
+
       visit people_path
+      expect(page).to have_content("Access Denied")
       expect(page).not_to have_content('Edit') #Need to scope this, or it will fail on Edith
       expect(page).not_to have_content(skill.name)
-      expect(page).to have_content("Access Denied")
 
       visit skill_path(skill)
+      expect(page).to have_content("Access Denied")
       expect(page).not_to have_content('Edit') #Need to scope this, or it will fail on Edith
       expect(page).not_to have_content(skill.name)
+
       visit edit_skill_path(skill)
       expect(page).to have_content("Access Denied")
     end

--- a/spec/features/authorization_skill_spec.rb
+++ b/spec/features/authorization_skill_spec.rb
@@ -1,21 +1,16 @@
 require 'rails_helper'
-      #save_and_open_page
+
 RSpec.describe "a user" do
   describe "without a role" do
-    before (:each) do
-      somebody = create(:user)
-      visit new_user_session_path
-      fill_in 'user_email', :with => somebody.email
-      fill_in 'user_password', :with => somebody.password
-      click_on 'Sign in'
-    end
+    before (:each) { sign_in_as(nil) } # no role
+
     it "cannot view skills" do
       skill = create(:skill)
       visit people_path
       expect(page).not_to have_content('Edit') #Need to scope this, or it will fail on Edith
       expect(page).not_to have_content(skill.name)
       expect(page).to have_content("Access Denied")
-      
+
       visit skill_path(skill)
       expect(page).not_to have_content('Edit') #Need to scope this, or it will fail on Edith
       expect(page).not_to have_content(skill.name)
@@ -23,16 +18,10 @@ RSpec.describe "a user" do
       expect(page).to have_content("Access Denied")
     end
   end
+
   describe "in the reader role" do
-    before (:each) do
-      somebody = create(:user)
-      r = create(:role, name: 'Reader')
-      somebody.roles << r
-      visit new_user_session_path
-      fill_in 'user_email', :with => somebody.email
-      fill_in 'user_password', :with => somebody.password
-      click_on 'Sign in'
-    end
+    before (:each) { sign_in_as('Reader') }
+
     it "cannot edit skills" do
       skill = create(:skill)
       visit edit_skill_path(skill)
@@ -51,17 +40,13 @@ RSpec.describe "a user" do
       expect(page).to have_content(skill.name)
     end
   end
+
   describe "in the editor role" do
     before (:each) do
       @person = create(:person)
-      somebody = create(:user)
-      r = create(:role, name: 'Editor')
-      somebody.roles << r
-      visit new_user_session_path
-      fill_in 'user_email', :with => somebody.email
-      fill_in 'user_password', :with => somebody.password
-      click_on 'Sign in'
+      sign_in_as('Editor')
     end
+
     it "can edit people" do
       visit people_path
       within_table("people") do

--- a/spec/features/authorization_spec.rb
+++ b/spec/features/authorization_spec.rb
@@ -1,17 +1,12 @@
 require 'rails_helper'
 
-      #save_and_open_page
 RSpec.describe "a user" do
   describe "in the reader role" do
     before (:each) do
       @person = create(:person)
-      somebody = create(:user)
-      somebody.roles << create(:role, name: 'Reader')
-      visit new_user_session_path
-      fill_in 'user_email', :with => somebody.email
-      fill_in 'user_password', :with => somebody.password
-      click_on 'Sign in'
+      sign_in_as('Reader')
     end
+
     it "cannot edit people" do
       visit people_path
       expect(page).not_to have_content('Edit') #Need to scope this, or it will fail on Edith
@@ -29,7 +24,8 @@ RSpec.describe "a user" do
       click_on @person.lastname
       expect(page).to have_content(@person.lastname)
     end
-end
+  end
+
 =begin
     it "a new person form with a first name field" do
       visit new_person_path
@@ -43,12 +39,12 @@ end
       firstaidskill = create(:skill, name: "FRFA")
       title.skills << drivingskill
       title.skills << firstaidskill
-      
+
       frfacourse = create(:course, name: "FRFA")
       firstaidskill.courses << frfacourse
       drivingcourse = create(:course, name: "Mass DL")
       drivingskill.courses << drivingcourse
-      
+
       person = create(:person)
       person.titles << title
       cert = create(:cert, person: person, course: frfacourse)

--- a/spec/features/authorization_trainer_spec.rb
+++ b/spec/features/authorization_trainer_spec.rb
@@ -1,15 +1,11 @@
 require 'rails_helper'
-      #save_and_open_page
+
 RSpec.describe "a user in the trainer role" do
   before (:each) do
     @person = create(:person)
-    somebody = create(:user)
-    somebody.roles << create(:role, name: 'Trainer')
-    visit new_user_session_path
-    fill_in 'user_email', :with => somebody.email
-    fill_in 'user_password', :with => somebody.password
-    click_on 'Sign in'
+    sign_in_as('Trainer')
   end
+
   it "cannot edit people" do
     visit edit_person_path(@person)
     expect(page).to have_content("Access Denied")

--- a/spec/features/availabilities_spec.rb
+++ b/spec/features/availabilities_spec.rb
@@ -1,15 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe "Availabilities" do
-  before (:each)  do
-    somebody = create(:user)
-    r = create(:role, name: 'Editor')
-    somebody.roles << r
-    visit new_user_session_path
-    fill_in 'user_email', :with => somebody.email
-    fill_in 'user_password', :with => somebody.password
-    click_on 'Sign in'
-  end
+  before(:each) { sign_in_as('Editor') }
 
   # get_basic_editor_views('availability',['person', 'description', 'status'])
 

--- a/spec/features/cert_displays_spec.rb
+++ b/spec/features/cert_displays_spec.rb
@@ -2,16 +2,8 @@ require 'rails_helper'
 #Don't use capybara (ie visit/have_content) and rspec matchers together  {response.status.should be(200)}
 
 RSpec.describe "Cert" do
-  before  do
-    somebody = create(:user)
-    r = create(:role, name: 'Editor')
-    somebody.roles << r
-   
-    visit new_user_session_path
-    fill_in('user_email', :with => somebody.email)
-    fill_in('user_password', :with => somebody.password)
-    click_on 'Sign in'
-  end
+  before(:each) { sign_in_as('Editor') }
+
   describe "when not logged in" do
     it "should not display anything" do
       click_on 'Sign Out'
@@ -27,12 +19,12 @@ RSpec.describe "Cert" do
       expect(page).to have_content('You need to sign in')
     end
   end
-      
+
   describe "should display" do
    it "a list" do
       cert = create(:cert)
       person = cert.person
-      
+
       visit certs_path
       expect(page).to have_content("Listing Certs")
       expect(page).to have_content("Home") # This is in the nav bar
@@ -50,11 +42,11 @@ RSpec.describe "Cert" do
       expect(page).to have_content("Issued Date")
       select(a_person.fullname, :from => 'cert_person_id')
       select(a_course.name, :from => 'cert_course_id')
-      
     end
+
     it 'should update a cert' do
-      
     end
+
     it "should show a cert page" do
       cert = create(:cert)
       visit cert_path(cert)

--- a/spec/features/channels_spec.rb
+++ b/spec/features/channels_spec.rb
@@ -1,15 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe "Channels" do
-  before (:each) do
-    somebody = create(:user)
-    r = create(:role, name: 'Editor')
-    somebody.roles << r
-    visit new_user_session_path
-    fill_in 'user_email', :with => somebody.email
-    fill_in 'user_password', :with => somebody.password
-    click_on 'Sign in'
-  end
-  
+  before(:each) { sign_in_as('Editor') }
+
   get_basic_editor_views('channel',['category'])
 end

--- a/spec/features/course_displays_spec.rb
+++ b/spec/features/course_displays_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 #Don't use capybara (ie visit/have_content) and rspec matchers together  {response.status.should be(200)}
 
-RSpec.describe "Course" do  
+RSpec.describe "Course" do
   describe " when not logged in" do
     it "should not allow much of anything" do
       visit courses_path
@@ -18,19 +18,10 @@ RSpec.describe "Course" do
       expect(page).not_to have_content('Pottery')
     end
   end
-      
-  describe "should display" do
-    before  do
-      somebody = create(:user)
-      r = create(:role, name: 'Editor')
-      somebody.roles << r
-      visit new_user_session_path
-      fill_in('user_email', :with => somebody.email)
-      fill_in('user_password', :with => somebody.password)
-      click_on 'Sign in'
-    end
 
-  
+  describe "should display" do
+    before(:each) { sign_in_as('Editor') }
+
    it "a list" do
       an_example = create(:course, name: 'Zombie Hunting')
       visit courses_path
@@ -58,7 +49,7 @@ RSpec.describe "Course" do
       visit courses_path
       expect(page).to have_content('Basket Weaving')
     end
-    
+
     it 'should update a course' do
       an_example = create(:course, name: 'Zombie Hunting')
       visit edit_course_path(an_example)

--- a/spec/features/events_spec.rb
+++ b/spec/features/events_spec.rb
@@ -1,15 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe "Events" do
-  before (:each)  do
-    somebody = create(:user)
-    r = create(:role, name: 'Editor')
-    somebody.roles << r
-    visit new_user_session_path
-    fill_in 'user_email', :with => somebody.email
-    fill_in 'user_password', :with => somebody.password
-    click_on 'Sign in'
-  end
+  before(:each) { sign_in_as('Editor') }
 
   get_basic_editor_views('event',['category', 'description', 'status'])
   describe "creates" do

--- a/spec/features/inspection_display_spec.rb
+++ b/spec/features/inspection_display_spec.rb
@@ -2,16 +2,8 @@ require 'rails_helper'
 #Don't use capybara (ie visit/have_content) and rspec matchers together  {response.status.should be(200)}
 
 RSpec.describe "Inspection" do
-  before (:each)  do
-    somebody = create(:user)
-    r = create(:role, name: 'Editor')
-    somebody.roles << r
+  before(:each) { sign_in_as('Editor') }
 
-    visit new_user_session_path
-    fill_in('user_email', :with => somebody.email)
-    fill_in('user_password', :with => somebody.password)
-    click_on 'Sign in'
-  end
   describe "when not logged in" do
     let(:an_item)  { create(:item) }
     let(:an_inspection) { create(:inspection, item: an_item) }

--- a/spec/features/items_spec.rb
+++ b/spec/features/items_spec.rb
@@ -1,15 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe Item do
-  before (:each) do
-    somebody = create(:user)
-    r = create(:role, name: 'Editor')
-    somebody.roles << r
-    visit new_user_session_path
-    fill_in 'user_email', :with => somebody.email
-    fill_in 'user_password', :with => somebody.password
-    click_on 'Sign in'
-  end
+  before(:each) { sign_in_as('Editor') }
 
   it "a new item form with appropriate fields" do
     visit new_item_path

--- a/spec/features/locations_spec.rb
+++ b/spec/features/locations_spec.rb
@@ -2,17 +2,8 @@ require 'rails_helper'
 
 RSpec.describe "Locations" do
   describe " visit locations" do
-    before (:each) do
-      somebody = create(:user)
-      r = create(:role, name: 'Editor')
-      somebody.roles << r
-      visit new_user_session_path
-      fill_in 'user_email', :with => somebody.email
-      fill_in 'user_password', :with => somebody.password
-      click_on 'Sign in'
-    end
-    
-    #sign_me_in
+    before (:each) { sign_in_as('Editor') }
+
     get_basic_editor_views('location',['name','category'])
   end
 end

--- a/spec/features/moves_spec.rb
+++ b/spec/features/moves_spec.rb
@@ -1,16 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe "Moves" do
-  before (:each) do
-    somebody = create(:user)
-    r = create(:role, name: 'Editor')
-    somebody.roles << r
-    visit new_user_session_path
-    fill_in 'user_email', :with => somebody.email
-    fill_in 'user_password', :with => somebody.password
-    click_on 'Sign in'
-  end
-  
+  before(:each) { sign_in_as('Editor') }
+
   get_basic_editor_views('move',['reason'])
-  
 end

--- a/spec/features/person_displays_spec.rb
+++ b/spec/features/person_displays_spec.rb
@@ -1,15 +1,7 @@
 require 'rails_helper'
-      #save_and_open_page
+
 RSpec.describe "Person" do
-  before (:each)  do
-    somebody = create(:user)
-    r = create(:role, name: 'Editor')
-    somebody.roles << r
-    visit new_user_session_path
-    fill_in 'user_email', :with => somebody.email
-    fill_in 'user_password', :with => somebody.password
-    click_on 'Sign in'
-  end
+  before(:each) { sign_in_as('Editor') }
 
   describe "views" do
     before (:each) do

--- a/spec/features/person_displays_spec.rb
+++ b/spec/features/person_displays_spec.rb
@@ -169,10 +169,11 @@ RSpec.describe "Person" do
       person = create(:person)
       person.titles << title
       cert = create(:cert, person: person, course: frfacourse)
+
       visit person_path(person)
-      #save_and_open_page
       expect(page).to have_content("NOT qualified for Police Officer")
       expect(page).to have_content("Driving") #This test is vague. Need to ensure Driving is in the missing skills section
+
       cert = create(:cert, person: person, course: drivingcourse)
       visit person_path(person)
       expect(page).to have_content("Qualified for Police Officer")

--- a/spec/features/person_edit_spec.rb
+++ b/spec/features/person_edit_spec.rb
@@ -66,11 +66,12 @@ RSpec.describe "Person" do
       person = create(:person)
       person.titles << title
       cert = create(:cert, person: person, course: frfacourse)
+
       visit person_path(person)
-      #save_and_open_page
       expect(page).to have_content("NOT qualified for Police Officer")
       expect(page).to have_content("Driving") #This test is vague. Need to ensure Driving is in the missing skills section
       cert = create(:cert, person: person, course: drivingcourse)
+
       visit person_path(person)
       expect(page).to have_content("Qualified for Police Officer")
       expect(page).not_to have_content("NOT Qualified")

--- a/spec/features/person_edit_spec.rb
+++ b/spec/features/person_edit_spec.rb
@@ -1,18 +1,11 @@
 require 'rails_helper'
-      #save_and_open_page
+
 RSpec.describe "Person" do
-  before (:each)  do
-    somebody = create(:user)
-    r = create(:role, name: 'Editor')
-    somebody.roles << r
-    visit new_user_session_path
-    fill_in 'user_email', :with => somebody.email
-    fill_in 'user_password', :with => somebody.password
-    click_on 'Sign in'
-  end
+  before(:each) { sign_in_as('Editor') }
 
   describe "views" do
     before (:each) do
+      # FIXME: This is never used
       cj = create(:person, firstname: 'CJ',  department: 'Police' )
       cj.channels << create(:channel, channel_type: 'Phone', content: '9785551212', category: "Mobile Phone")
       sierra = create(:person, firstname: 'Sierra', department: 'CERT' )
@@ -24,7 +17,6 @@ RSpec.describe "Person" do
       create(:person, firstname: 'Donna', status: 'Declined' )
       create(:person, firstname: 'Oscar', status: 'Active', department: 'Other' )
     end
-
   end
 
   describe "forms should display" do

--- a/spec/features/repairs_spec.rb
+++ b/spec/features/repairs_spec.rb
@@ -1,15 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe "Repairs" do
-  before (:each)  do
-    somebody = create(:user)
-    r = create(:role, name: 'Editor')
-    somebody.roles << r
-    visit new_user_session_path
-    fill_in 'user_email', :with => somebody.email
-    fill_in 'user_password', :with => somebody.password
-    click_on 'Sign in'
-  end
+  before(:each) { sign_in_as('Editor') }
 
   describe "GET /repairs" do
     it "returns a page" do

--- a/spec/features/roles_spec.rb
+++ b/spec/features/roles_spec.rb
@@ -1,22 +1,13 @@
 require 'rails_helper'
 
 RSpec.describe "Roles" do
-  before (:each)  do
-    somebody = create(:user)
-    r = create(:role, name: 'Editor')
-    somebody.roles << r
-    visit new_user_session_path
-    fill_in 'user_email', :with => somebody.email
-    fill_in 'user_password', :with => somebody.password
-    click_on 'Sign in'
-  end
+  before (:each) { sign_in_as('Editor') }
 
   describe "GET /roles" do
     it "works!" do
       # Run the generator again with the --webrat flag if you want to use webrat methods/matchers
       visit roles_path
       expect(page).to have_content("Listing Roles")
-      
     end
   end
 end

--- a/spec/features/tasks_spec.rb
+++ b/spec/features/tasks_spec.rb
@@ -1,15 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe "Tasks" do
-  before (:each)  do
-    somebody = create(:user)
-    r = create(:role, name: 'Editor')
-    somebody.roles << r
-    visit new_user_session_path
-    fill_in 'user_email', :with => somebody.email
-    fill_in 'user_password', :with => somebody.password
-    click_on 'Sign in'
-  end
+  before(:each) { sign_in_as('Editor') }
 
   get_nested_editor_views('event', 'task', ['title', 'description', 'street'])
 

--- a/spec/features/timeslots_spec.rb
+++ b/spec/features/timeslots_spec.rb
@@ -13,15 +13,7 @@ RSpec.describe 'Access on timecard' do
 end
 
 RSpec.describe Timecard do
-  before (:each) do
-    somebody = create(:user)
-    r = create(:role, name: "Editor")
-    somebody.roles << r
-    visit new_user_session_path
-    fill_in 'user_email', :with => somebody.email
-    fill_in 'user_password', :with => somebody.password
-    click_on 'Sign in'
-  end
+  before(:each) { sign_in_as('Editor') }
 
   it "gets the index" do
     @sample_object = create(:timecard)

--- a/spec/features/timeslots_spec.rb
+++ b/spec/features/timeslots_spec.rb
@@ -1,12 +1,14 @@
 require 'rails_helper'
-#save_and_open_page
+
 RSpec.describe 'Access on timecard' do
   it "gets denied" do
     visit timecards_path
     expect(page).to have_content("You need to sign in")
+
     visit new_timecard_path
     expect(page).to have_content("You need to sign in")
     @sample_object = create(:timecard)
+
     visit url_for(@sample_object)
     expect(page).to have_content("You need to sign in")
   end
@@ -41,13 +43,16 @@ RSpec.describe Timecard do
   end
   it "visits a display page without actual times" do
     @sample_object = create(:timecard, intended_start_time: nil, intended_end_time: nil, actual_start_time: nil, actual_end_time: nil)
+
     visit timecard_path(@sample_object)
     expect(page).to have_content("Home")
     expect(page).to have_css('#sidebar')
     expect(page).to have_content(@sample_object.category)
     expect(page).to have_content(@sample_object.intention)
+
     visit timecards_path
     expect(page).to have_content("Home")
+
     visit person_path(@sample_object.person)
     expect(page).to have_content("Home")
   end

--- a/spec/features/users_spec.rb
+++ b/spec/features/users_spec.rb
@@ -12,15 +12,7 @@ RSpec.describe 'Access on user' do
   end
 end
 RSpec.describe "user" do
-  before (:each) do
-    somebody = create(:user)
-    r = create(:role, name: "Manager")
-    somebody.roles << r
-    visit new_user_session_path
-    fill_in 'user_email', :with => somebody.email
-    fill_in 'user_password', :with => somebody.password
-    click_on 'Sign in'
-  end
+  before (:each) { sign_in_as('Manager') }
 
   it "gets the index" do
     @user = create(:user, lastname: "Doe")

--- a/spec/features/users_spec.rb
+++ b/spec/features/users_spec.rb
@@ -1,16 +1,19 @@
 require 'rails_helper'
-#save_and_open_page
+
 RSpec.describe 'Access on user' do
   it "gets denied when not logged in" do
     visit users_path
     expect(page).to have_content("need to sign in")
     @user = create(:user)
+
     visit url_for(@user)
     expect(page).to have_content("need to sign in")
+
     visit edit_user_path(@user)
     expect(page).to have_content("need to sign in")
   end
 end
+
 RSpec.describe "user" do
   before (:each) { sign_in_as('Manager') }
 

--- a/spec/support/authentication_helper.rb
+++ b/spec/support/authentication_helper.rb
@@ -1,11 +1,17 @@
 module AuthenticationHelper
-  def sign_me_in
+  def sign_in_as(role_name)
     somebody = create(:user)
-    r = create(:role, name: 'Editor')
-    somebody.roles << r
+    if role_name
+      r = create(:role, name: role_name)
+      somebody.roles << r
+    end
     visit new_user_session_path
-    fill_in 'user_email', :with => somebody.email
-    fill_in 'user_password', :with => somebody.password
+    fill_in 'user_email', with: somebody.email
+    fill_in 'user_password', with: somebody.password
     click_on 'Sign in'
   end
+end
+
+RSpec.configure do |c|
+  c.include AuthenticationHelper, type: :feature
 end


### PR DESCRIPTION
Added a helper function and made some small cleanups.

In feature specs, instead of:

```
before (:each) do
    somebody = create(:user)
    r = create(:role, name: 'Reader')
    somebody.roles << r
    visit new_user_session_path
    fill_in 'user_email', :with => somebody.email
    fill_in 'user_password', :with => somebody.password
    click_on 'Sign in'
end
```

use:

```
before (:each) { sign_in_as('Reader') }
```
