### PR TITLE
'Cancel Edit' links go back

### DIFF
--- a/app/views/activities/edit.html.erb
+++ b/app/views/activities/edit.html.erb
@@ -1,7 +1,6 @@
 <% content_for :sidebar do %>
   <h1>Editing activity</h1>
-  <%= sidebar_button_link 'Show', @activity %>
-  <%= sidebar_button_link 'Back', activities_path %>
+  <%= sidebar_button_link 'Cancel Edit', :back %>
 <% end %>
 
 <%= render 'form' %>

--- a/app/views/availabilities/edit.html.erb
+++ b/app/views/availabilities/edit.html.erb
@@ -1,7 +1,6 @@
 <% content_for :sidebar do %>
   <h1>Editing Availability</h1>
-  <%= sidebar_button_link 'Show', @availability.person %>
-  <%= sidebar_button_link 'Back', availabilities_path %>
+  <%= sidebar_button_link 'Cancel Edit', :back %>
 <% end %>
 
 <%= render 'form' %>

--- a/app/views/certs/edit.html.erb
+++ b/app/views/certs/edit.html.erb
@@ -1,6 +1,6 @@
 <% content_for :sidebar do %>
   <h1>Editing Cert</h1>
-  <%= sidebar_button_link 'Cancel', certs_path %>
+  <%= sidebar_button_link 'Cancel Edit', :back %>
 <% end %>
 
 <%= render 'form' %>

--- a/app/views/channels/edit.html.erb
+++ b/app/views/channels/edit.html.erb
@@ -1,7 +1,6 @@
 <% content_for :sidebar do %>
   <h1>Editing channel</h1>
-  <%= sidebar_button_link 'Show', @channel %>
-  <%= sidebar_button_link 'Back', channels_path %>
+  <%= sidebar_button_link 'Cancel Edit', :back %>
 <% end %>
 
 <%= render 'form' %>

--- a/app/views/courses/edit.html.erb
+++ b/app/views/courses/edit.html.erb
@@ -1,6 +1,6 @@
 <% content_for :sidebar do %>
   <h1>Editing course</h1>
-  <%= sidebar_button_link 'Cancel', people_path %>
+  <%= sidebar_button_link 'Cancel Edit', :back %>
 <% end %>
 
 <%= render 'form' %>

--- a/app/views/departments/edit.html.erb
+++ b/app/views/departments/edit.html.erb
@@ -1,7 +1,6 @@
 <% content_for :sidebar do %>
   <h1>Editing department</h1>
-  <%= sidebar_button_link 'Show', @department %>
-  <%= sidebar_button_link 'Back', departments_path %>
+  <%= sidebar_button_link 'Cancel Edit', :back %>
 <% end %>
 
 <%= render 'form' %>

--- a/app/views/events/edit.html.erb
+++ b/app/views/events/edit.html.erb
@@ -1,6 +1,6 @@
 <% content_for :sidebar do %>
   <h3>Editing Event</h3>
-  <%= sidebar_button_link 'Cancel', events_path %><br/>
+  <%= sidebar_button_link 'Cancel Edit', :back %>
 <% end %>
- 
+
 <%= render 'form' %>

--- a/app/views/helpdocs/edit.html.erb
+++ b/app/views/helpdocs/edit.html.erb
@@ -1,7 +1,6 @@
 <% content_for :sidebar do %>
   <h1>Editing helpdoc</h1>
-  <%= sidebar_button_link 'Show', @helpdoc %>
-  <%= sidebar_button_link 'Back', helpdocs_path %>
+  <%= sidebar_button_link 'Cancel Edit', :back %>
 <% end %>
 
 <%= render 'form' %>

--- a/app/views/inspections/edit.html.erb
+++ b/app/views/inspections/edit.html.erb
@@ -1,9 +1,7 @@
 <% content_for :sidebar do %>
   <h2>Edit Inspection</h2>
   <h3>(for <%= @inspection.item.name %>)</h3>
-  <%= sidebar_button_link 'Return to Item', @inspection.item %>
-  <%= sidebar_button_link 'Return to Inspections List', inspections_path %>
-  <%= sidebar_button_link 'Show Inspection', @inspection %>
+  <%= sidebar_button_link 'Cancel Edit', :back %>
 <% end %>
 
 <%= render 'form' %>

--- a/app/views/item_types/edit.html.erb
+++ b/app/views/item_types/edit.html.erb
@@ -1,7 +1,6 @@
 <% content_for :sidebar do %>
   <h1>Editing Item Type</h1>
-  <%= sidebar_button_link 'Show', @item_type %>
-  <%= sidebar_button_link 'Back', item_types_path %>
+  <%= sidebar_button_link 'Cancel Edit', :back %>
 <% end %>
 
 <%= render 'form' %>

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -1,7 +1,6 @@
 <% content_for :sidebar do %>
   <h1>Editing Item</h1>
-  <%= sidebar_button_link 'Cancel', items_path %>
+  <%= sidebar_button_link 'Cancel Edit', :back %>
 <% end %>
-
 
 <%= render 'form' %>

--- a/app/views/locations/edit.html.erb
+++ b/app/views/locations/edit.html.erb
@@ -1,7 +1,6 @@
 <% content_for :sidebar do %>
   <h1>Editing location</h1>
-  <%= sidebar_button_link 'Show', @location %>
-  <%= sidebar_button_link 'Back', locations_path %>
+  <%= sidebar_button_link 'Cancel Edit', :back %>
 <% end %>
 
 <%= render 'form' %>

--- a/app/views/moves/edit.html.erb
+++ b/app/views/moves/edit.html.erb
@@ -1,7 +1,6 @@
 <% content_for :sidebar do %>
   <h1>Editing move</h1>
-  <%= sidebar_button_link 'Show', @move %>
-  <%= sidebar_button_link 'Back', moves_path %>
+  <%= sidebar_button_link 'Cancel Edit', :back %>
 <% end %>
 
 <%= render 'form' %>

--- a/app/views/people/edit.html.erb
+++ b/app/views/people/edit.html.erb
@@ -1,6 +1,6 @@
 <% content_for :sidebar do %>
   <h1>Editing Person</h1>
-  <%= sidebar_button_link 'Cancel', :back %>
+  <%= sidebar_button_link 'Cancel Edit', :back %>
   <br>
   <%= image_tag @person.portrait_url if @person.portrait.file.present? %>
 <% end %>

--- a/app/views/repairs/edit.html.erb
+++ b/app/views/repairs/edit.html.erb
@@ -1,7 +1,6 @@
 <% content_for :sidebar do %>
   <h1>Editing Repair</h1>
-  <%= sidebar_button_link 'Items List', items_path %>
+  <%= sidebar_button_link 'Cancel Edit', :back %>
 <% end %>
 
 <%= render 'form' %>
-

--- a/app/views/resource_types/edit.html.erb
+++ b/app/views/resource_types/edit.html.erb
@@ -1,7 +1,6 @@
 <% content_for :sidebar do %>
   <h1>Editing Resource Type</h1>
-  <%= sidebar_button_link 'Show', @resource_type %>
-  <%= sidebar_button_link 'Back', resource_types_path %>
+  <%= sidebar_button_link 'Cancel Edit', :back %>
 <% end %>
 
 <%= render 'form' %>

--- a/app/views/roles/edit.html.erb
+++ b/app/views/roles/edit.html.erb
@@ -1,7 +1,6 @@
 <% content_for :sidebar do %>
   <h1>Editing role</h1>
-  <%= sidebar_button_link 'Show', @role %>
-  <%= sidebar_button_link 'Back', roles_path %>
+  <%= sidebar_button_link 'Cancel Edit', :back %>
 <% end %>
 
 <%= render 'form' %>

--- a/app/views/skills/edit.html.erb
+++ b/app/views/skills/edit.html.erb
@@ -1,6 +1,6 @@
 <% content_for :sidebar do %>
   <h1>Editing Skill <%= @skill.name %></h1>
-  <%= sidebar_button_link 'Cancel', skills_path %>
+  <%= sidebar_button_link 'Cancel Edit', :back %>
 <% end %>
 
 

--- a/app/views/tasks/edit.html.erb
+++ b/app/views/tasks/edit.html.erb
@@ -1,9 +1,7 @@
 <% content_for :sidebar do %>
   <h2>Edit Task</h2>
   <h3>(for <%= @task.event.title %>)</h3>
-  <%= sidebar_button_link 'Return to Event', @task.event %>
-  <%= sidebar_button_link 'Return to Tasks List', tasks_path %>
-  <%= sidebar_button_link 'Show Task', @task %>
+  <%= sidebar_button_link 'Cancel Edit', :back %>
 <% end %>
 
 <%= render 'form' %>

--- a/app/views/timecards/edit.html.erb
+++ b/app/views/timecards/edit.html.erb
@@ -1,4 +1,6 @@
-<h1>Editing Timecard</h1>
+<% content_for :sidebar do %>
+  <h1>Editing Timecard</h1>
+  <%= sidebar_button_link 'Cancel Edit', :back %>
+<% end %>
 
 <%= render 'form' %>
-

--- a/app/views/titles/edit.html.erb
+++ b/app/views/titles/edit.html.erb
@@ -1,3 +1,6 @@
-<h1>Editing title</h1>
+<% content_for :sidebar do %>
+  <h1>Editing Title</h1>
+  <%= sidebar_button_link 'Cancel Edit', :back %>
+<% end %>
 
 <%= render 'form' %>

--- a/app/views/unique_ids/edit.html.erb
+++ b/app/views/unique_ids/edit.html.erb
@@ -1,7 +1,6 @@
 <% content_for :sidebar do %>
   <h1>Editing unique_id</h1>
-  <%= sidebar_button_link 'Show', @unique_id %>
-  <%= sidebar_button_link 'Back', unique_ids_path %>
+  <%= sidebar_button_link 'Cancel Edit', :back %>
 <% end %>
 
   <%= render 'form' %>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -1,6 +1,6 @@
 <% content_for :sidebar do %>
   <h1>Editing User</h1>
-  <%= sidebar_button_link 'Cancel', users_path %>
+  <%= sidebar_button_link 'Cancel Edit', :back %>
 <% end %>
 
 <%= render 'form' %>


### PR DESCRIPTION
give uniform behavior to `edit` pages, with a 'Cancel Edit' link that goes `:back`
