### PR TITLE
Add bootstrap tabs to events

### DIFF
--- a/app/assets/javascripts/events.js.coffee
+++ b/app/assets/javascripts/events.js.coffee
@@ -2,13 +2,18 @@ jQuery ->
   $("#event_title").focus();
   $("#event_category").change ->
     temp = $("#event_category option:selected").text();
-    if temp is "Training" 
+    if temp is "Training"
       $(".training-controls").show()
     else
       $(".training-controls").hide()
   $("#event_status").change ->
     status = $("#event_status option:selected").text();
     start_time = $("#event_start_time").text();
-    if status is "Completed" 
+    if status is "Completed"
       $("#XXevent_start_time").hide()
-    
+
+  $('a[data-toggle="tab"]').on 'shown.bs.tab', (e) ->
+    $.fn.dataTable.tables(
+      visible: true
+      api: true).columns.adjust()
+    return

--- a/app/assets/stylesheets/events.scss
+++ b/app/assets/stylesheets/events.scss
@@ -17,3 +17,16 @@
     color: #666;
   }
 }
+
+.event-tabs {
+  margin-top: 20px;
+  margin-bottom: 20px;
+
+  .event-tabs-anchor{
+    font-size: 20px;
+  }
+
+  .tab-pane {
+    margin-top: 10px;
+  }
+}

--- a/app/views/availabilities/_availabilities_table.html.erb
+++ b/app/views/availabilities/_availabilities_table.html.erb
@@ -1,5 +1,4 @@
 <table id="availabilities" class="generic_datatable table table-striped table-bordered">
-  <caption><h3><%= "Availability" %></h3></caption>
   <thead>
     <tr>
       <th>Status</th>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -26,16 +26,28 @@
 <% end %>
 <%= display_event_status(@event) %>
 
-<%= render(partial: 'tasks/tasks_table', locals: { tasks: @event.tasks}) %>
+<div class='event-tabs'>
+  <ul class="nav nav-tabs">
+    <li class="active"><a class='event-tabs-anchor' href="#event-task-tab" data-toggle="tab">Tasks</a></li>
+    <li><a class='event-tabs-anchor' href="#event-availability-tab" data-toggle="tab">Availabilities</a></li>
+  </ul>
 
-<div id="event_availabilities" >
-  <%= render(:partial => "availabilities/availabilities_table",
-             :locals => { :availabilities => ( @event.responses)} ) || "No Availabilities yet !" %>
+  <div class="tab-content">
+    <div class="tab-pane active" id="event-task-tab">
+      <%= render(partial: 'tasks/tasks_table', locals: { tasks: @event.tasks}) %>
+    </div>
+    <div class="tab-pane" id="event-availability-tab">
+      <div id="event_availabilities" >
+        <%= render(:partial => "availabilities/availabilities_table",
+                   :locals => { :availabilities => ( @event.responses)} ) || "No Availabilities yet !" %>
 
-  <%= render(partial: "people/people_table",
-             locals: { people: @event.unresponsive_people,
-                       title: "No Response",
-                       row_class: 'class="warning"'}) || "Everyone Responded !" %>
+        <%= render(partial: "people/people_table",
+                   locals: { people: @event.unresponsive_people,
+                             title: "No Response",
+                             row_class: 'class="warning"'}) || "Everyone Responded !" %>
+      </div>
+    </div>
+  </div>
 </div>
 
 <% if @event.comments.present? %>

--- a/app/views/tasks/_tasks_table.html.erb
+++ b/app/views/tasks/_tasks_table.html.erb
@@ -1,5 +1,4 @@
 <table id="event_tasks" class="datatable table table-striped table-bordered">
-  <caption><h3><%= "Tasks" %></h3></caption>
   <thead>
     <tr>
       <th>Title</th>


### PR DESCRIPTION
Added bootstrap tab functionality as it was quicker to implement and matched the existing bootstrap theme of the site.

<img width="1279" alt="screen shot 2016-10-21 at 11 42 59 pm" src="https://cloud.githubusercontent.com/assets/8333278/19616743/595de572-97e9-11e6-94d0-81a9db048afb.png">
<img width="1276" alt="screen shot 2016-10-21 at 11 43 58 pm" src="https://cloud.githubusercontent.com/assets/8333278/19616744/5967a0da-97e9-11e6-8998-e591a0c7d43d.png">
