### PR TITLE
Feature/change event listing

### DIFF
--- a/app/assets/stylesheets/events.scss
+++ b/app/assets/stylesheets/events.scss
@@ -30,3 +30,8 @@
     margin-top: 10px;
   }
 }
+
+.event-labels {
+  font-size: 15px;
+  margin-left: 3px;
+}

--- a/app/helpers/availabilities_helper.rb
+++ b/app/helpers/availabilities_helper.rb
@@ -1,25 +1,30 @@
 module AvailabilitiesHelper
-  def availability_status_label(availability)
-    content_tag(:span, availability.status, class: availability_label_class(availability))
+  def availability_status_label(availability, event = nil)
+    if availability.partially_available?(event)
+      content_tag(:span, availability.status == "Available" ? "Partially Available" : availability.status, class: availability_label_class(availability, true))
+    else
+      content_tag(:span, availability.status, class: availability_label_class(availability, false))
+    end
   end
 
-  def availability_status_class(availability)
+  def availability_status_class(availability, event = nil)
     case availability.status
     when 'Available'
-      return 'class="success"'
+      return availability.partially_available?(event) ? 'class="warning"' : 'class="success"'
     when 'Unavailable', 'Cancelled'
       return 'class="danger"'
     else
       return nil
     end
   end
+
   private
-    def availability_label_class(availability)
+    def availability_label_class(availability, partial)
       # The options are found in app/models/availability.rb: STATUS_CHOICES
       return nil if availability.status.blank?
       case availability.status
       when 'Available'
-        return 'label label-success'
+        return partial ? 'label label-warning' : 'label label-success'
       when 'Unavailable'
         return 'label label-danger'
       else

--- a/app/helpers/events_helper.rb
+++ b/app/helpers/events_helper.rb
@@ -5,18 +5,18 @@ module EventsHelper
   end
 
   def display_event_status(event)
-    available    = event.availabilities.count.to_s
-    partial      = event.partial_availabilities.count.to_s
-    unavailable  = event.unavailabilities.count.to_s
-    no_response  = event.unresponsive_people.count.to_s
+    available            = event.availabilities.count.to_s
+    partially_available  = event.partial_availabilities.count.to_s
+    unavailable          = event.unavailabilities.count.to_s
+    no_response          = event.unresponsive_people.count.to_s
     content_tag(:div) {
       capture do
         concat event_status_label(event)
         concat content_tag(:span, 'Personnel:', class: 'event-labels')
-        concat make_label(available, 'label label-success event-labels', tooltip: 'available')
-        concat make_label(partial, 'label label-warning event-labels', tooltip: 'available')
-        concat make_label(unavailable, 'label label-danger event-labels', tooltip: 'unavailable')
-        concat make_label(no_response, 'label label-default event-labels', tooltip: 'no response')
+        concat make_label(available, 'label label-success event-labels', tooltip: 'Available')
+        concat make_label(partially_available, 'label label-warning event-labels', tooltip: 'Partially Available')
+        concat make_label(unavailable, 'label label-danger event-labels', tooltip: 'Unavailable')
+        concat make_label(no_response, 'label label-default event-labels', tooltip: 'No Response')
       end
     }
   end

--- a/app/helpers/events_helper.rb
+++ b/app/helpers/events_helper.rb
@@ -12,9 +12,7 @@ module EventsHelper
     content_tag(:div) {
       capture do
         concat event_status_label(event)
-
         concat content_tag(:span, 'Personnel:', class: 'event-labels')
-        # concat " Personnel: "
         concat make_label(available, 'label label-success event-labels', tooltip: 'available')
         concat make_label(partial, 'label label-warning event-labels', tooltip: 'available')
         concat make_label(unavailable, 'label label-danger event-labels', tooltip: 'unavailable')

--- a/app/helpers/events_helper.rb
+++ b/app/helpers/events_helper.rb
@@ -6,18 +6,19 @@ module EventsHelper
 
   def display_event_status(event)
     available    = event.availabilities.count.to_s
+    partial      = event.partial_availabilities.count.to_s
     unavailable  = event.unavailabilities.count.to_s
     no_response  = event.unresponsive_people.count.to_s
     content_tag(:div) {
       capture do
         concat event_status_label(event)
-        concat " (Personnel: "
-        concat make_label(available, 'label label-success', tooltip: 'available')
-        concat "/"
-        concat make_label(unavailable, 'label label-danger', tooltip: 'unavailable')
-        concat "/"
-        concat make_label(no_response, 'label label-warning', tooltip: 'no response')
-        concat ")"
+
+        concat content_tag(:span, 'Personnel:', class: 'event-labels')
+        # concat " Personnel: "
+        concat make_label(available, 'label label-success event-labels', tooltip: 'available')
+        concat make_label(partial, 'label label-warning event-labels', tooltip: 'available')
+        concat make_label(unavailable, 'label label-danger event-labels', tooltip: 'unavailable')
+        concat make_label(no_response, 'label label-default event-labels', tooltip: 'no response')
       end
     }
   end

--- a/app/models/availability.rb
+++ b/app/models/availability.rb
@@ -6,9 +6,19 @@ class Availability < ActiveRecord::Base
 
   STATUS = [ 'Available', 'Unavailable', "Cancelled" ]
 
-  scope :for_time_span, ->(range) { where("end_time >= ?", range.first).
-                               where("start_time <= ?", range.last) }
+  # Available the entire event
+  scope :for_time_span, ->(range) { where("end_time >= ?", range.last).
+                               where("start_time <= ?", range.first) }
+
+  # Available part of event
+  scope :partially_available, ->(range) { where("? >= end_time AND end_time >= ? OR ? >= start_time AND start_time >= ?", range.last, range.first, range.last, range.first) }
+
 
   scope :available, -> { where(status: "Available")}
   scope :unavailable, -> { where(status: "Unavailable")}
+
+  def partially_available?(event)
+    return false if event.nil?
+    (event.end_time >= self.end_time && self.end_time >= event.start_time) || (event.end_time >= self.start_time && self.start_time >= event.start_time)
+  end
 end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -32,8 +32,21 @@ class Event < ActiveRecord::Base
   end
 
   def unavailabilities
-    responses.unavailable
+    responses.unavailable + partial_responses.unavailable
   end
+
+  def partial_responses
+    Availability.partially_available(self.start_time..self.end_time)
+  end
+
+  def partial_availabilities
+    partial_responses.available
+  end
+
+  def partial_respondents
+    self.partial_responses.map { |a| a.person }
+  end
+
 
   def availabilities
     responses.available
@@ -57,7 +70,7 @@ class Event < ActiveRecord::Base
   end
 
   def unresponsive_people
-    eligible_people - respondents
+    eligible_people - respondents - partial_respondents
   end
 
   def manhours

--- a/app/views/availabilities/_availabilities_table.html.erb
+++ b/app/views/availabilities/_availabilities_table.html.erb
@@ -11,9 +11,10 @@
     </tr>
   </thead>
   <tbody>
-    <% availabilities.each do |availability| %>
-      <tr <%== availability_status_class(availability) %>>
-        <td><%= availability_status_label(availability) %></td>
+      <!-- Full available -->
+    <% (availabilities + partial_availabilities).each do |availability| %>
+      <tr <%== availability_status_class(availability, @event) %>>
+        <td><%= availability_status_label(availability, @event) %></td>
         <td><%= availability.person.icsid %></td>
         <td><%= link_to availability.person.fullname, availability_path(availability) %></td>
         <td><%= number_to_phone(availability.person.phone) %></td>
@@ -22,5 +23,6 @@
         <td><%= truncate(availability.description, length: 24) %></td>
       </tr>
     <% end %>
+
   </tbody>
 </table>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -39,12 +39,13 @@
     <div class="tab-pane" id="event-availability-tab">
       <div id="event_availabilities" >
         <%= render(:partial => "availabilities/availabilities_table",
-                   :locals => { :availabilities => ( @event.responses)} ) || "No Availabilities yet !" %>
+                   :locals => { :availabilities => ( @event.responses),
+                                :partial_availabilities => ( @event.partial_responses)} ) || "No Availabilities yet !" %>
 
         <%= render(partial: "people/people_table",
                    locals: { people: @event.unresponsive_people,
                              title: "No Response",
-                             row_class: 'class="warning"'}) || "Everyone Responded !" %>
+                             row_class: 'class="default"'}) || "Everyone Responded !" %>
       </div>
     </div>
   </div>


### PR DESCRIPTION
…ing helpers to create the proper labels/styling

There were a few ways I was thinking about doing this but I ended up going this route. Tried to cut down on duplication where possible.

Updated the for_time_span scope to only return users whose availability is a superset of the events time range. The partially_available scope only returns users who have partial availability. 

<img width="1277" alt="screen shot 2016-10-22 at 8 06 07 pm" src="https://cloud.githubusercontent.com/assets/8333278/19623315/0765025a-9893-11e6-9dd0-8948e6a4ee75.png">
<img width="1280" alt="screen shot 2016-10-22 at 8 06 13 pm" src="https://cloud.githubusercontent.com/assets/8333278/19623316/0765b9ac-9893-11e6-9cee-cb464a62bbb7.png">
