### PR TITLE
Make end_time's datepicker default to displaying the start_time

### DIFF
--- a/app/assets/javascripts/events.js.coffee
+++ b/app/assets/javascripts/events.js.coffee
@@ -17,3 +17,9 @@ jQuery ->
       visible: true
       api: true).columns.adjust()
     return
+
+  $('#event_start_time').change ->
+    eventStartTime = $('#event_start_time').datetimepicker('getValue')
+    eventEndTime = $('#event_end_time').datetimepicker('getValue')
+    if (not eventEndTime?) or (eventStartTime > eventEndTime)
+      $('#event_end_time').datetimepicker('setOptions', {startDate: eventStartTime})


### PR DESCRIPTION
Every time the start date is changed on an Event, update the end time datepicker's startDate, so the datepicker will default to displaying a reasonable initial date.  Fixes #252
