### PR TITLE
Move definition of constants to initializers folder

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -30,8 +30,5 @@ module ReadyResponder
 
     # Do not swallow errors in after_commit/after_rollback callbacks.
     config.active_record.raise_in_transactional_callbacks = true
-
-    # Hold Google maps API key
-    GOOGLE_MAPS_API_KEY = Rails.application.secrets.GOOGLE_MAPS_API_KEY
   end
 end

--- a/config/initializers/constants.rb
+++ b/config/initializers/constants.rb
@@ -1,0 +1,2 @@
+# Hold Google maps API key
+GOOGLE_MAPS_API_KEY = Rails.application.secrets.GOOGLE_MAPS_API_KEY


### PR DESCRIPTION
The `GOOGLE_MAPS_API_KEY` was not accessible in the rails application when defined in the `application.rb` file. I don't know why this is happening. May be something to do with namespaces.

But based on the below documentation in `application.rb` file, I moved the same code to `initializers/constants.rb` and voila it worked.

```
    # Application configuration should go into files in config/initializers
    # -- all .rb files in that directory are automatically loaded.
```

I am not looking at resources to understand why this is happening. @kgf if you find something do let me know. Thanks :)
