### PR TITLE
Create commentable concern and link person to comments model

### DIFF
--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -164,7 +164,7 @@ class PeopleController < ApplicationController
       :city, :state, :zipcode, :start_date, :end_date,
       :application_date, :title, :gender, :portrait, :date_of_birth,
       :division1, :division2, :channels_attributes, :title_ids,
-      :title_order, :comments,
+      :title_order, :old_comments,
       :channels_attributes => [],
       :title_ids => [],
       phones_attributes: [:id, :category, :content, :name, :status, :usage, :carrier, :sms_available, :priority, :channel_type],

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -1,0 +1,3 @@
+class Comment < ActiveRecord::Base
+  belongs_to :commentable, :polymorphic => true
+end

--- a/app/models/concerns/commentable.rb
+++ b/app/models/concerns/commentable.rb
@@ -1,0 +1,8 @@
+module Commentable
+  extend ActiveSupport::Concern
+
+  included do
+    has_many :comments, dependent: :destroy
+  end
+
+end

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -1,5 +1,7 @@
 class Person < ActiveRecord::Base
   has_paper_trail
+  include Commentable
+
   include ActiveModel::ForbiddenAttributesProtection
   mount_uploader :portrait, PortraitUploader
 

--- a/app/views/people/_form.html.erb
+++ b/app/views/people/_form.html.erb
@@ -58,6 +58,6 @@
     <h4> Personnel Image </h4>
     <%= @person.portrait %>
     <%= f.file_field :portrait %>
-    <%= f.input :comments, :input_html => { :size => 40} %>
+    <%= f.input :old_comments, :input_html => { :size => 40} %>
     <%= f.button :submit %>
 <% end %>

--- a/db/migrate/20161030131223_create_comments.rb
+++ b/db/migrate/20161030131223_create_comments.rb
@@ -1,0 +1,11 @@
+class CreateComments < ActiveRecord::Migration
+  def change
+    create_table :comments do |t|
+      t.string :title, :limit => 50, :default => "" 
+      t.text :description
+      t.references :commentable, :polymorphic => true
+      t.references :person
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/migrate/20161112151536_rename_comments_field_on_person.rb
+++ b/db/migrate/20161112151536_rename_comments_field_on_person.rb
@@ -1,0 +1,5 @@
+class RenameCommentsFieldOnPerson < ActiveRecord::Migration
+  def change
+    rename_column :people, :comments, :old_comments
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161105063525) do
+ActiveRecord::Schema.define(version: 20161112151536) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -78,6 +78,16 @@ ActiveRecord::Schema.define(version: 20161105063525) do
   add_index "channels", ["category"], name: "index_channels_on_category", using: :btree
   add_index "channels", ["person_id"], name: "index_channels_on_person_id", using: :btree
   add_index "channels", ["priority"], name: "index_channels_on_priority", using: :btree
+
+  create_table "comments", force: :cascade do |t|
+    t.string   "title",            limit: 50, default: ""
+    t.text     "description"
+    t.integer  "commentable_id"
+    t.string   "commentable_type"
+    t.integer  "person_id"
+    t.datetime "created_at",                               null: false
+    t.datetime "updated_at",                               null: false
+  end
 
   create_table "courses", force: :cascade do |t|
     t.string   "name"
@@ -294,7 +304,7 @@ ActiveRecord::Schema.define(version: 20161105063525) do
     t.string   "blood_type",       limit: 12
     t.string   "allergies"
     t.string   "passwordhash"
-    t.text     "comments"
+    t.text     "old_comments"
     t.decimal  "total_hours",                 precision: 7, scale: 2
     t.date     "start_date"
     t.date     "end_date"

--- a/spec/factories/comments.rb
+++ b/spec/factories/comments.rb
@@ -1,0 +1,5 @@
+FactoryGirl.define do
+  factory :comment do
+    
+  end
+end

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Comment, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
Hi @kgf, I am facing a issue wherein the specs are failing because I already see a text column `comments` and that is clashing with the `Comment` model I am introducing.
Is there a use for keeping the text field ?

Also can you confirm that The new comments model has the following db design. Hope I got that part of the requirements ready.

```
  create_table "comments", force: :cascade do |t|
    t.string   "title",            limit: 50, default: ""
    t.text     "description"
    t.integer  "commentable_id"
    t.string   "commentable_type"
    t.integer  "person_id"
    t.datetime "created_at",                               null: false
    t.datetime "updated_at",                               null: false
  end
```

_TODO_: Display comments made by person on the person view page.
