### PR TITLE
Add Notifications tab to Event page

### DIFF
--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -30,6 +30,7 @@
   <ul class="nav nav-tabs">
     <li class="active"><a class='event-tabs-anchor' href="#event-task-tab" data-toggle="tab">Tasks</a></li>
     <li><a class='event-tabs-anchor' href="#event-availability-tab" data-toggle="tab">Availabilities</a></li>
+    <li><a class='event-tabs-anchor' href='#event-notification-tab' data-toggle="tab">Notifications</a></li>
   </ul>
 
   <div class="tab-content">
@@ -46,6 +47,10 @@
                    locals: { people: @event.unresponsive_people,
                              title: "No Response" }) || "Everyone Responded !" %>
       </div>
+    </div>
+    <div class="tab-pane" id="event-notification-tab">
+      <%= render(partial: 'notifications/notifications_table', 
+                 locals: { notifications: @event.notifications }) %>
     </div>
   </div>
 </div>

--- a/app/views/notifications/_notifications_table.html.erb
+++ b/app/views/notifications/_notifications_table.html.erb
@@ -11,7 +11,8 @@
       <th colspan="1"></th>
     </tr>
   </thead>
-I need to allow info only Notifications
+
+  <%# TODO: I need to allow info only Notifications %>
   <tbody>
     <% notifications.each do |notification| %>
       <tr>

--- a/app/views/notifications/_notifications_table.html.erb
+++ b/app/views/notifications/_notifications_table.html.erb
@@ -1,0 +1,26 @@
+<table id="notifications" class="generic_datatable table table-striped table-bordered">
+  <% if defined? title %>
+    <caption><h3><%= title %></h3></caption>
+  <% end %>
+  <thead>
+    <tr>
+      <th>Status</th>
+      <th>Event</th>
+      <th>Start at</th>
+      <th>Channels</th>
+      <th colspan="1"></th>
+    </tr>
+  </thead>
+I need to allow info only Notifications
+  <tbody>
+    <% notifications.each do |notification| %>
+      <tr>
+        <td><%= notification.status %></td>
+        <td><%= notification.event ? (link_to notification.event.title, notification.event) : 'None' %></td>
+        <td><%= notification.scheduled_start_time %></td>
+        <td><%= notification.channels %></td>
+        <td><%= link_to 'Edit', edit_notification_path(notification) %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/notifications/_notifications_table.html.erb
+++ b/app/views/notifications/_notifications_table.html.erb
@@ -20,7 +20,7 @@
         <td><%= notification.event ? (link_to notification.event.title, notification.event) : 'None' %></td>
         <td><%= notification.scheduled_start_time %></td>
         <td><%= notification.channels %></td>
-        <td><%= link_to 'Edit', edit_notification_path(notification) %></td>
+        <td><%= link_to 'Edit', edit_notification_path(notification) if can? :update, notification %></td>
       </tr>
     <% end %>
   </tbody>

--- a/app/views/notifications/index.html.erb
+++ b/app/views/notifications/index.html.erb
@@ -3,29 +3,6 @@
   <%= sidebar_button_link 'New', new_notification_path %>
 <% end %>
 
-<table id="notifications" class="generic_datatable table table-striped table-bordered">
-  <caption><h3><%= @page_title %></h3></caption>
-  <thead>
-    <tr>
-      <th>Status</th>
-      <th>Event</th>
-      <th>Start at</th>
-      <th>Channels</th>
-      <th colspan="1"></th>
-    </tr>
-  </thead>
-I need to allow info only Notifications
-  <tbody>
-    <% @notifications.each do |notification| %>
-      <tr>
-        <td><%= notification.status %></td>
-        <td><%= notification.event ? (link_to notification.event.title, notification.event) : 'None' %></td>
-        <td><%= notification.scheduled_start_time %></td>
-        <td><%= notification.channels %></td>
-        <td><%= link_to 'Edit', edit_notification_path(notification) %></td>
-      </tr>
-    <% end %>
-  </tbody>
-</table>
+<%= render(partial: 'notifications/notifications_table', locals: { notifications: @notifications, title: @page_title }) %>
 
 <br>

--- a/spec/views/notifications/index.html.erb_spec.rb
+++ b/spec/views/notifications/index.html.erb_spec.rb
@@ -1,6 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe "notifications/index", type: :view do
+  let(:user) { FactoryGirl.create :user }
   before(:each) do
     assign(:notifications, [
       Notification.create!(
@@ -14,6 +15,7 @@ RSpec.describe "notifications/index", type: :view do
         :channels => "Channels"
       )
     ])
+    allow(controller).to receive(:current_user).and_return(user)
   end
 
   it "renders a list of notifications" do


### PR DESCRIPTION
Moved Notifications table into a partial and use it in the Event display.  Resolves #275.