### PR TITLE
Add some attributes to Notification and implement I18n for channels

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,7 @@ gem 'rmagick', '~> 2.15.4'
 gem 'simple_form'
 gem 'geocoder'
 gem 'cancancan'
+gem 'rails-i18n', '~> 4.0.0'
 #gem "taps"
 #gem 'validates_timeliness', '~> 3.0'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -249,6 +249,9 @@ GEM
       rails-deprecated_sanitizer (>= 1.0.1)
     rails-html-sanitizer (1.0.3)
       loofah (~> 2.0)
+    rails-i18n (4.0.9)
+      i18n (~> 0.7)
+      railties (~> 4.0)
     railties (4.2.7)
       actionpack (= 4.2.7)
       activesupport (= 4.2.7)
@@ -398,6 +401,7 @@ DEPENDENCIES
   rack
   rails (= 4.2.7)
   rails-assets-datetimepicker!
+  rails-i18n (~> 4.0.0)
   ransack
   rmagick (~> 2.15.4)
   rspec-rails
@@ -415,4 +419,4 @@ DEPENDENCIES
   web-console (~> 3.0)
 
 BUNDLED WITH
-   1.13.2
+   1.13.6

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,6 +4,7 @@ class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
   before_filter :configure_permitted_parameters, if: :devise_controller?
   before_action :set_paper_trail_whodunnit
+  before_action :set_locale
 
   rescue_from CanCan::AccessDenied do |exception|
     flash[:error] = "Access Denied"
@@ -17,8 +18,17 @@ class ApplicationController < ActionController::Base
   end
 
   protected
-    def configure_permitted_parameters
-      devise_parameter_sanitizer.for(:sign_up) << :username
-      devise_parameter_sanitizer.for(:account_update) << :username
-    end
+
+  def configure_permitted_parameters
+    devise_parameter_sanitizer.for(:sign_up) << :username
+    devise_parameter_sanitizer.for(:account_update) << :username
+  end
+
+  def default_url_options
+    { locale: I18n.locale }
+  end
+
+  def set_locale
+    I18n.locale = params[:locale] || I18n.default_locale
+  end
 end

--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -56,8 +56,8 @@ class NotificationsController < ApplicationController
 
     # Only allow a trusted parameter "white list" through.
     def notification_params
-      params.require(:notification).permit(:event_id, :author_id, :status,
-         :time_to_live, :interval, :iterations_to_escalation, :groups,
-          :scheduled_start_time, :start_time, :channels, :departments, :divisions)
+      params.require(:notification).permit(:subject, :body, :event_id, :author_id, :status,
+          :time_to_live, :interval, :iterations_to_escalation, :groups, :scheduled_start_time,
+          :start_time, :channels, :departments, :divisions)
     end
 end

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -1,9 +1,23 @@
 class Notification < ActiveRecord::Base
+  VALID_CHANNELS = [EMAIL = 'email', VOICE = 'voice', TEXT = 'text']
+  VALID_STATUSES = [PENDING = 'pending', ACTIVE = 'active', CANCELED = 'canceled',
+      COMPLETE = 'complete', EXPIRED = 'expired']
+
   belongs_to :event
-  # has_many :recipients
 
-  VALID_STATUSES = %w(pending active canceled complete expired)
+  validates :subject, :body, presence: true
   validates :status, inclusion: { in: VALID_STATUSES }
+  validate :channels, :channels_include_only_valid_values
 
+  def channels=(text)
+    self[:channels] = text.downcase
+  end
 
+  private
+
+  def channels_include_only_valid_values
+    if channels.present? && (channels.split(' ') - VALID_CHANNELS).present?
+      errors.add(:channels, I18n.t('activerecord.errors.models.notification.attributes.channels.invalid'))
+    end
+  end
 end

--- a/app/views/notifications/_form.html.erb
+++ b/app/views/notifications/_form.html.erb
@@ -2,6 +2,8 @@
   <%= f.error_notification %>
 
   <div class="form-inputs">
+    <%= f.input :subject %>
+    <%= f.input :body %>
     <%= f.association :event %>
     <%= f.input :status, as: :select, collection: Notification::VALID_STATUSES %>
     <%= f.input :time_to_live, hint: 'Length to keep trying to notify non-responders, in hours' %>

--- a/app/views/notifications/index.html.erb
+++ b/app/views/notifications/index.html.erb
@@ -10,7 +10,7 @@
       <th>Status</th>
       <th>Event</th>
       <th>Start at</th>
-      <th>Channels</th>
+      <th><%= t('.channels.header') %></th>
       <th colspan="1"></th>
     </tr>
   </thead>
@@ -21,7 +21,11 @@ I need to allow info only Notifications
         <td><%= notification.status %></td>
         <td><%= notification.event ? (link_to notification.event.title, notification.event) : 'None' %></td>
         <td><%= notification.scheduled_start_time %></td>
-        <td><%= notification.channels %></td>
+        <td>
+          <% notification.channels.split(' ').each do |channel| %>
+            <span><%= t(".channels.#{channel}") %></span>
+          <% end %>
+        </td>
         <td><%= link_to 'Edit', edit_notification_path(notification) %></td>
       </tr>
     <% end %>

--- a/app/views/notifications/show.html.erb
+++ b/app/views/notifications/show.html.erb
@@ -7,7 +7,16 @@
 <p id="notice"><%= notice %></p>
 
 <p>
+  <strong><%= t('.subject') %></strong>
+  <%= @notification.subject %>
+</p>
 
+<p>
+  <strong><%= t('.body') %></strong>
+  <%= @notification.body %>
+</p>
+
+<p>
   <strong>Event:</strong>
   <%= @event_title %>
 </p>
@@ -39,7 +48,9 @@
 
 <p>
   <strong>Channels:</strong>
-  <%= @notification.channels %>
+  <% @notification.channels.split(' ').each do |channel| %>
+    <span><%= t(".channels.#{channel}") %></span>
+  <% end %>
 </p>
 
 <p>

--- a/config/locales/active_record.en.yml
+++ b/config/locales/active_record.en.yml
@@ -1,0 +1,44 @@
+en:
+  activerecord:
+    attributes:
+      notification:
+        channels: Channels
+    errors:
+      messages:
+        accepted: "must be accepted"
+        blank: "can't be blank"
+        confirmation: "must match"
+        edit_not_authorized: "Edit is not allowed as it is not authorized for this user."
+        empty: "can't be empty"
+        end_date_after_start_date: "must be after the Start Date"
+        equal_to: "must be equal to %{count}"
+        even: "must be even"
+        exclusion: "is reserved"
+        greater_than: "must be greater than %{count}"
+        greater_than_or_equal_to: "must be greater than or equal to %{count}"
+        inclusion: "is not included in the list"
+        invalid: "is invalid"
+        less_than: "must be less than %{count}"
+        less_than_or_equal_to: "must be less than or equal to %{count}"
+        must_be_empty: "must not be selected"
+        not_a_date: "must be a valid date"
+        not_a_datetime: "must be a valid datetime"
+        not_a_number: "is not a number"
+        odd: "must be odd"
+        password: "must be at least 6 characters with 1 letter and 1 number"
+        required: "is required"
+        taken: "has already been taken"
+        too_long: "is too long (maximum is %{count} characters)"
+        too_short: "is too short (minimum is %{count} characters)"
+        wrong_length: "is the wrong length (should be %{count} characters)"
+      models:
+        notification:
+          attributes:
+            channels:
+              invalid: "Channels must be some set of <email>, <text>, and <voice> with spaces between each value" 
+      template:
+        body: "Please review the problems below:"
+        header:
+          one: "1 error prevented this from being saved:"
+          other: "%{count} errors prevented this from being saved:"
+      

--- a/config/locales/active_record.en.yml
+++ b/config/locales/active_record.en.yml
@@ -4,41 +4,9 @@ en:
       notification:
         channels: Channels
     errors:
-      messages:
-        accepted: "must be accepted"
-        blank: "can't be blank"
-        confirmation: "must match"
-        edit_not_authorized: "Edit is not allowed as it is not authorized for this user."
-        empty: "can't be empty"
-        end_date_after_start_date: "must be after the Start Date"
-        equal_to: "must be equal to %{count}"
-        even: "must be even"
-        exclusion: "is reserved"
-        greater_than: "must be greater than %{count}"
-        greater_than_or_equal_to: "must be greater than or equal to %{count}"
-        inclusion: "is not included in the list"
-        invalid: "is invalid"
-        less_than: "must be less than %{count}"
-        less_than_or_equal_to: "must be less than or equal to %{count}"
-        must_be_empty: "must not be selected"
-        not_a_date: "must be a valid date"
-        not_a_datetime: "must be a valid datetime"
-        not_a_number: "is not a number"
-        odd: "must be odd"
-        password: "must be at least 6 characters with 1 letter and 1 number"
-        required: "is required"
-        taken: "has already been taken"
-        too_long: "is too long (maximum is %{count} characters)"
-        too_short: "is too short (minimum is %{count} characters)"
-        wrong_length: "is the wrong length (should be %{count} characters)"
       models:
         notification:
           attributes:
             channels:
-              invalid: "Channels must be some set of <email>, <text>, and <voice> with spaces between each value" 
-      template:
-        body: "Please review the problems below:"
-        header:
-          one: "1 error prevented this from being saved:"
-          other: "%{count} errors prevented this from being saved:"
+              invalid: "Channels must be some set of <email>, <text>, and <voice> with spaces between each value"
       

--- a/config/locales/active_record.es.yml
+++ b/config/locales/active_record.es.yml
@@ -1,0 +1,44 @@
+es:
+  activerecord:
+    attributes:
+      notification:
+        channels: Canales
+    errors:
+      messages:
+        accepted: "must be accepted"
+        blank: "can't be blank"
+        confirmation: "must match"
+        edit_not_authorized: "Edit is not allowed as it is not authorized for this user."
+        empty: "can't be empty"
+        end_date_after_start_date: "must be after the Start Date"
+        equal_to: "must be equal to %{count}"
+        even: "must be even"
+        exclusion: "is reserved"
+        greater_than: "must be greater than %{count}"
+        greater_than_or_equal_to: "must be greater than or equal to %{count}"
+        inclusion: "is not included in the list"
+        invalid: "is invalid"
+        less_than: "must be less than %{count}"
+        less_than_or_equal_to: "must be less than or equal to %{count}"
+        must_be_empty: "must not be selected"
+        not_a_date: "must be a valid date"
+        not_a_datetime: "must be a valid datetime"
+        not_a_number: "is not a number"
+        odd: "must be odd"
+        password: "must be at least 6 characters with 1 letter and 1 number"
+        required: "is required"
+        taken: "has already been taken"
+        too_long: "is too long (maximum is %{count} characters)"
+        too_short: "is too short (minimum is %{count} characters)"
+        wrong_length: "is the wrong length (should be %{count} characters)"
+      models:
+        notification:
+          attributes:
+            channels:
+              invalid: "Los canales deben tener algún conjunto de <email>, <text> y <voice> con espacios entre cada valor" 
+      template:
+        body: "Please review the problems below:"
+        header:
+          one: "1 error prevented this from being saved:"
+          other: "%{count} errors prevented this from being saved:"
+      

--- a/config/locales/active_record.es.yml
+++ b/config/locales/active_record.es.yml
@@ -4,41 +4,8 @@ es:
       notification:
         channels: Canales
     errors:
-      messages:
-        accepted: "must be accepted"
-        blank: "can't be blank"
-        confirmation: "must match"
-        edit_not_authorized: "Edit is not allowed as it is not authorized for this user."
-        empty: "can't be empty"
-        end_date_after_start_date: "must be after the Start Date"
-        equal_to: "must be equal to %{count}"
-        even: "must be even"
-        exclusion: "is reserved"
-        greater_than: "must be greater than %{count}"
-        greater_than_or_equal_to: "must be greater than or equal to %{count}"
-        inclusion: "is not included in the list"
-        invalid: "is invalid"
-        less_than: "must be less than %{count}"
-        less_than_or_equal_to: "must be less than or equal to %{count}"
-        must_be_empty: "must not be selected"
-        not_a_date: "must be a valid date"
-        not_a_datetime: "must be a valid datetime"
-        not_a_number: "is not a number"
-        odd: "must be odd"
-        password: "must be at least 6 characters with 1 letter and 1 number"
-        required: "is required"
-        taken: "has already been taken"
-        too_long: "is too long (maximum is %{count} characters)"
-        too_short: "is too short (minimum is %{count} characters)"
-        wrong_length: "is the wrong length (should be %{count} characters)"
       models:
         notification:
           attributes:
             channels:
               invalid: "Los canales deben tener algún conjunto de <email>, <text> y <voice> con espacios entre cada valor" 
-      template:
-        body: "Please review the problems below:"
-        header:
-          one: "1 error prevented this from being saved:"
-          other: "%{count} errors prevented this from being saved:"
-      

--- a/config/locales/devise.es.yml
+++ b/config/locales/devise.es.yml
@@ -1,0 +1,58 @@
+# Additional translations at https://github.com/plataformatec/devise/wiki/I18n
+
+es:
+  errors:
+    messages:
+      expired: "has expired, please request a new one"
+      not_found: "not found"
+      already_confirmed: "was already confirmed, please try signing in"
+      not_locked: "was not locked"
+      not_saved:
+        one: "1 error prohibited this %{resource} from being saved:"
+        other: "%{count} errors prohibited this %{resource} from being saved:"
+
+  devise:
+    failure:
+      already_authenticated: 'You are already signed in.'
+      unauthenticated: 'You need to sign in or sign up before continuing.'
+      unconfirmed: 'You have to confirm your account before continuing.'
+      locked: 'Your account is locked.'
+      invalid: 'Invalid email or password.'
+      invalid_token: 'Invalid authentication token.'
+      timeout: 'Your session expired, please sign in again to continue.'
+      inactive: 'Your account was not activated yet.'
+    sessions:
+      signed_in: 'Signed in successfully.'
+      signed_out: 'Signed out successfully.'
+    passwords:
+      send_instructions: 'You will receive an email with instructions about how to reset your password in a few minutes.'
+      updated: 'Your password was changed successfully. You are now signed in.'
+      updated_not_active: 'Your password was changed successfully.'
+      send_paranoid_instructions: "If your email address exists in our database, you will receive a password recovery link at your email address in a few minutes."
+      no_token: "You can't access this page without coming from a password reset email. If you do come from a password reset email, please make sure you used the full URL provided."
+    confirmations:
+      send_instructions: 'You will receive an email with instructions about how to confirm your account in a few minutes.'
+      send_paranoid_instructions: 'If your email address exists in our database, you will receive an email with instructions about how to confirm your account in a few minutes.'
+      confirmed: 'Your account was successfully confirmed. You are now signed in.'
+    registrations:
+      signed_up: 'Welcome! You have signed up successfully.'
+      signed_up_but_unconfirmed: 'A message with a confirmation link has been sent to your email address. Please open the link to activate your account.'
+      signed_up_but_inactive: 'You have signed up successfully. However, we could not sign you in because your account is not yet activated.'
+      signed_up_but_locked: 'You have signed up successfully. However, we could not sign you in because your account is locked.'
+      updated: 'You updated your account successfully.'
+      update_needs_confirmation: "You updated your account successfully, but we need to verify your new email address. Please check your email and click on the confirm link to finalize confirming your new email address."
+      destroyed: 'Bye! Your account was successfully cancelled. We hope to see you again soon.'
+    unlocks:
+      send_instructions: 'You will receive an email with instructions about how to unlock your account in a few minutes.'
+      unlocked: 'Your account has been unlocked successfully. Please sign in to continue.'
+      send_paranoid_instructions: 'If your account exists, you will receive an email with instructions about how to unlock it in a few minutes.'
+    omniauth_callbacks:
+      success: 'Successfully authenticated from %{kind} account.'
+      failure: 'Could not authenticate you from %{kind} because "%{reason}".'
+    mailer:
+      confirmation_instructions:
+        subject: 'Confirmation instructions'
+      reset_password_instructions:
+        subject: 'Reset password instructions'
+      unlock_instructions:
+        subject: 'Unlock Instructions'

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1,0 +1,11 @@
+es:
+  hello: "Hola Mundo"
+  date:
+    formats:
+      default: "%m/%d/%Y"
+      short: "%m/%d"
+  datetime:
+    formats:
+      default: "%m/%d/%Y %H:%M"
+      short: "%H:%M"
+      notime: "%m/%d/%Y"

--- a/config/locales/simple_form.es.yml
+++ b/config/locales/simple_form.es.yml
@@ -1,0 +1,31 @@
+es:
+  simple_form:
+    "yes": 'Yes'
+    "no": 'No'
+    required:
+      text: 'required'
+      mark: '*'
+      # You can uncomment the line below if you need to overwrite the whole required html.
+      # When using html, text and mark won't be used.
+      # html: '<abbr title="required">*</abbr>'
+    error_notification:
+      default_message: "Please review the problems below:"
+    # Examples
+    # labels:
+    #   defaults:
+    #     password: 'Password'
+    #   user:
+    #     new:
+    #       email: 'E-mail to sign in.'
+    #     edit:
+    #       email: 'E-mail.'
+    # hints:
+    #   defaults:
+    #     username: 'User name to sign in.'
+    #     password: 'No special characters, please.'
+    # include_blanks:
+    #   defaults:
+    #     age: 'Rather not say'
+    # prompts:
+    #   defaults:
+    #     age: 'Select your age'

--- a/config/locales/views.en.yml
+++ b/config/locales/views.en.yml
@@ -1,0 +1,16 @@
+en:
+  notifications:
+    show:
+      subject: Subject
+      body: Content
+      channels:
+        email: Email
+        text: Text
+        voice: Telephone
+    index:
+      channels:
+        header: Channels
+        email: Email
+        text: SMS
+        voice: Phone
+

--- a/config/locales/views.es.yml
+++ b/config/locales/views.es.yml
@@ -1,0 +1,15 @@
+es:
+  notifications:
+    show:
+      subject: Tema
+      body: Contenido
+      channels:
+        email: E-mail
+        text: SMS
+        voice: Teléfono
+    index:
+      channels:
+        header: Canales
+        email: E-mail
+        text: SMS
+        voice: Fon

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,82 +1,85 @@
 Rails.application.routes.draw do
-  resources :notifications
-  resources :availabilities
-  resources :unique_ids
-
-  resources :item_types
-
-  resources :resource_types
-  resources :messages
-  resources :activities
-  resources :helpdocs
-  resources :channels
-  resources :departments
-  resources :timecards
-  resources :roles
-
-  post 'events/:id/schedule/:person_id/:card_action', to: 'events#schedule', as: 'schedule'
-
-  resources :moves
-  resources :locations
-
-  resources :repairs
-  resources :inspections, except: [:new, :create], constraints: { id: /\d+/ }
-  resources :items do
-    resources :repairs
-    resources :inspections, only: [:new, :create]
-  end
-
-  get '/uploads/item/item_image/:id/:basename.:extension', controller: 'items', action: 'download', type: 'item_image'
-  get '/uploads/person/portrait/:id/:basename.:extension', controller: 'people', action: 'download', type: 'portrait'
-  get '/uploads/cert/certification/:id/:basename.:extension', controller: 'certs', action: 'download', type: 'certification'
-
-  get 'landing/help', as: 'help', path: '/help'
-
-  devise_for :users
-  resources :users
-
-  resources :titles
-  resources :skills
-  resources :courses
-  resources :certs
-
-  resources :analytics do
-    get 'calendar_chart', on: :collection
-  end
-
-  resources :requirements, except: [:new, :create], constraints: { id: /\d+/ }
-
-  resources :tasks, except: [:new, :create], constraints: { id: /\d+/ } do
-    resources :requirements, only: [:new, :create]
-  end
-
-  resources :events do
-    resources :tasks, only: [:new, :create]
+  scope "(:locale)", locale: /en|es/ do
+    resources :notifications
     resources :availabilities
-  end
+    resources :unique_ids
 
-  resources :people do
-    collection do
-      get 'inactive'
-      get 'leave'
-      get 'other'
-      get 'everybody'
-      get 'applicants'
-      get 'prospects'
-      get 'declined'
-      get 'cert'
-      get 'police'
-      get 'signin'
-      get 'orgchart'
-      get 'roster'
-    end
-    resources :certs
-    resources :availabilities
-    resources :titles
-    resources :items
+    resources :item_types
+
+    resources :resource_types
+    resources :messages
+    resources :activities
+    resources :helpdocs
     resources :channels
+    resources :departments
+    resources :timecards
+    resources :roles
+
+    post 'events/:id/schedule/:person_id/:card_action', to: 'events#schedule', as: 'schedule'
+
+    resources :moves
+    resources :locations
+
+    resources :repairs
+    resources :inspections, except: [:new, :create], constraints: { id: /\d+/ }
+    resources :items do
+      resources :repairs
+      resources :inspections, only: [:new, :create]
+    end
+
+    get '/uploads/item/item_image/:id/:basename.:extension', controller: 'items', action: 'download', type: 'item_image'
+    get '/uploads/person/portrait/:id/:basename.:extension', controller: 'people', action: 'download', type: 'portrait'
+    get '/uploads/cert/certification/:id/:basename.:extension', controller: 'certs', action: 'download', type: 'certification'
+
+    get 'landing/help', as: 'help', path: '/help'
+
+    devise_for :users
+    resources :users
+
+    resources :titles
+    resources :skills
+    resources :courses
+    resources :certs
+
+    resources :analytics do
+      get 'calendar_chart', on: :collection
+    end
+
+    resources :requirements, except: [:new, :create], constraints: { id: /\d+/ }
+
+    resources :tasks, except: [:new, :create], constraints: { id: /\d+/ } do
+      resources :requirements, only: [:new, :create]
+    end
+
+    resources :events do
+      resources :tasks, only: [:new, :create]
+      resources :availabilities
+    end
+
+    resources :people do
+      collection do
+        get 'inactive'
+        get 'leave'
+        get 'other'
+        get 'everybody'
+        get 'applicants'
+        get 'prospects'
+        get 'declined'
+        get 'cert'
+        get 'police'
+        get 'signin'
+        get 'orgchart'
+        get 'roster'
+      end
+      resources :certs
+      resources :availabilities
+      resources :titles
+      resources :items
+      resources :channels
+    end
+
+    root "landing#index"
   end
-
-  root "landing#index"
-
+  
+  get '/:locale' => 'landing#index'
 end

--- a/db/migrate/20161105063525_add_attributes_to_notification.rb
+++ b/db/migrate/20161105063525_add_attributes_to_notification.rb
@@ -1,0 +1,6 @@
+class AddAttributesToNotification < ActiveRecord::Migration
+  def change
+    add_column :notifications, :subject, :string
+    add_column :notifications, :body, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161029014201) do
+ActiveRecord::Schema.define(version: 20161105063525) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -263,6 +263,8 @@ ActiveRecord::Schema.define(version: 20161029014201) do
     t.text     "divisions"
     t.datetime "created_at",               null: false
     t.datetime "updated_at",               null: false
+    t.string   "subject"
+    t.text     "body"
   end
 
   add_index "notifications", ["event_id"], name: "index_notifications_on_event_id", using: :btree

--- a/spec/factories/notifications.rb
+++ b/spec/factories/notifications.rb
@@ -1,7 +1,9 @@
 FactoryGirl.define do
   factory :notification do
+    subject "An Important Title"
+    body "A devastating message, which is very significant."
     status "active"
     start_time "2016-09-26 22:21:34"
-    channels "Email Text"
+    channels "email text"
   end
 end

--- a/spec/models/notification_spec.rb
+++ b/spec/models/notification_spec.rb
@@ -5,25 +5,23 @@ RSpec.describe Notification do
     it 'can belong to an event' do
       expect(subject).to belong_to(:event)
     end
-
-    it 'has many recipients'
   end
 
   describe 'validations' do
-    context 'status' do
-      it 'accepts a valid status' do
-        notification = build(:notification, status: 'pending')
+    it { is_expected.to validate_presence_of(:subject) }
+    it { is_expected.to validate_presence_of(:body) }
+    it { is_expected.to validate_inclusion_of(:status).in_array(%w(pending active canceled complete expired)) }
+
+    context 'channels' do
+      it 'accepts a valid set of channels' do
+        notification = build(:notification, channels: 'email text voice')
         expect(notification).to be_valid
       end
 
-      it 'rejects an invalid status' do
-        notification = build(:notification, status: 'fake_status')
+      it 'rejects an invalid set of channels' do
+        notification = build(:notification, status: 'email carrier-pidgeon')
         expect(notification).to_not be_valid
       end
     end
-
-
   end
-
-
 end


### PR DESCRIPTION
This is a proof of concept for I18n.

We need to do actual translations, all the locale files have translations that are only for demo purposes. 
Use channels as a reference.

Things to do now:
- Pick the right wording for channels and channel categories
- Pick the right wording for notification subject and body
- Pick a locale, and translate it.
- Grab existing translations for simpleform and devise
 
Things to do later:
- Might want to add a database-backed I18n backend and a front-end to make it easy to contribute translations
- Maybe implement keywords (though, I don't recommend it)
- Localize javascript

To view the difference try playing around with notifications, creating, viewing, editing, and index, and pay attention to the channels:

For English: `localhost:3000/en/notifications` or `localhost:3000/notifications`
For Spanish: `localhost:3000/es/notifications`
