### PR TITLE
Make top menu dynamic for people

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -53,11 +53,13 @@ group :development do
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
   gem 'spring'
 
-  # Call 'byebug' anywhere in the code to stop execution and get a debugger console
-  gem 'byebug'
-
   # Use Capistrano for deployment
   gem 'capistrano-rails'
+end
+
+group :development, :test do
+  # Call 'byebug' anywhere in the code to stop execution and get a debugger console
+  gem 'byebug'
 end
 
 group :production do

--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -27,16 +27,10 @@ class PeopleController < ApplicationController
     render :template => "people/index"
   end
 
-  def police
-    redirect_to department_people_path("Police")
-  end
   def everybody
     @people = Person
     @page_title = "Everybody"
     render :template => "people/index"
-  end
-  def cert
-    redirect_to department_people_path("CERT")
   end
 
   def other

--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -16,11 +16,19 @@ class PeopleController < ApplicationController
     @page_title = "Org Chart"
     render :layout => "orgchart"
   end
+  
+  def department
+    dept = Department.find(params[:dept_id])
+    # TODO: more gracefully handle department not found
+    head 404 and return if dept.nil?
+    
+    @people = Person.active.where(department_id: dept.id)
+    @page_title = dept.name
+    render :template => "people/index"
+  end
 
   def police
-    @people = Person.active.select{|person| person.department&.name == "Police"}
-    @page_title = "Police"
-    render :template => "people/index"
+    redirect_to department_people_path("Police")
   end
   def everybody
     @people = Person
@@ -28,9 +36,7 @@ class PeopleController < ApplicationController
     render :template => "people/index"
   end
   def cert
-    @people = Person.active.select{|person| person.department&.name == "CERT"} + Person.cert.all
-    @page_title = "CERT"
-    render :template => "people/index"
+    redirect_to department_people_path("CERT")
   end
 
   def other

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -10,7 +10,7 @@ class Ability
     elsif roles.include? "Manager"
       can :manage, :all
     elsif roles.include? "Editor"
-      can [:read, :update, :create, :edit, :police, :cert, :applicants, :prospects, :other, :inactive, :leave, :declined, :everybody], Person
+      can [:read, :update, :create, :edit, :department, :applicants, :prospects, :other, :inactive, :leave, :declined, :everybody], Person
       can [:read, :update, :create, :edit], Timecard
       can [:read, :update, :create, :edit], Channel
       can [:read, :update, :create, :edit], Availability

--- a/app/models/department.rb
+++ b/app/models/department.rb
@@ -8,6 +8,10 @@ class Department < ActiveRecord::Base
   has_many :items
   has_many :locations
   has_and_belongs_to_many :notifications
+  
+  validates_presence_of :shortname
+  
+  scope :active, -> { where( status: "Active" ) }
 
 
   def self.managing_people

--- a/app/views/layouts/_top_menu.html.erb
+++ b/app/views/layouts/_top_menu.html.erb
@@ -15,7 +15,7 @@
           <li class="dropdown">
             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button">People<span class="caret"></span></a>
             <ul class="dropdown-menu">
-              <% Department.managing_people.order("shortname ASC").each do |dept| %>
+              <% Department.active.managing_people.order("shortname ASC").each do |dept| %>
                 <%= nav_link dept.shortname, department_people_path(dept) %>
               <% end %>
               <%= nav_link "Active", people_path %>

--- a/app/views/layouts/_top_menu.html.erb
+++ b/app/views/layouts/_top_menu.html.erb
@@ -15,8 +15,9 @@
           <li class="dropdown">
             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button">People<span class="caret"></span></a>
             <ul class="dropdown-menu">
-              <%= nav_link "Police", police_people_path %>
-              <%= nav_link "CERT", cert_people_path %>
+              <% Department.managing_people.order("shortname ASC").each do |dept| %>
+                <%= nav_link dept.shortname, department_people_path(dept) %>
+              <% end %>
               <%= nav_link "Active", people_path %>
               <%= nav_link "Others Active", other_people_path %>
               <%= nav_link "Everybody", everybody_people_path %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -70,8 +70,6 @@ Rails.application.routes.draw do
       get 'applicants'
       get 'prospects'
       get 'declined'
-      get 'cert'
-      get 'police'
       get 'signin'
       get 'orgchart'
       get 'roster'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -75,6 +75,7 @@ Rails.application.routes.draw do
       get 'signin'
       get 'orgchart'
       get 'roster'
+      get 'department/:dept_id', action: "department", as: :department
     end
     resources :certs
     resources :availabilities

--- a/db/migrate/20161208043524_enforce_department_shortname_required.rb
+++ b/db/migrate/20161208043524_enforce_department_shortname_required.rb
@@ -1,0 +1,13 @@
+class EnforceDepartmentShortnameRequired < ActiveRecord::Migration
+  def change
+    
+    # use raw sql to update any departments with null shortname
+    Department.where(shortname: nil).update_all("shortname = name")
+    
+    # at this point, there may still be departments with nil name and shortname
+    Department.where(shortname: nil).each_with_index {|d, i| d.update_columns(shortname: "dept_#{i}")}
+    
+    # finally, it should be safe to set shortname to null: false
+    change_column :departments, :shortname, :string, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161122015809) do
+ActiveRecord::Schema.define(version: 20161208043524) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -110,7 +110,7 @@ ActiveRecord::Schema.define(version: 20161122015809) do
 
   create_table "departments", force: :cascade do |t|
     t.string   "name",          limit: 255
-    t.string   "shortname",     limit: 255
+    t.string   "shortname",                                 null: false
     t.string   "status",        limit: 255
     t.integer  "contact_id"
     t.text     "description"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -31,15 +31,17 @@ Role.find_or_create_by(name: "Reader")
 
 # Departments are where people call home.
 Department.create([
-  {name: "Department Public Works", status: "Active", division1: ["Division 1", "Division 2"], division2: ["Squad 1", "Squad 2"]},
-  {name: "Inactive Department", status: "Inactive", division1: ["Division 1", "Division 2"], division2: ["Squad 1", "Squad 2"]},
-  {name: "Police", status: "Active", division1: ["Division 1", "Division 2"], division2: ["Squad 1", "Squad 2"]}
+  {name: "Department Public Works", shortname: "DPW", status: "Active", division1: ["Division 1", "Division 2"], division2: ["Squad 1", "Squad 2"]},
+  {name: "Inactive Department", shortname: "inactive", status: "Inactive", division1: ["Division 1", "Division 2"], division2: ["Squad 1", "Squad 2"]},
+  {name: "Police", shortname: "BAUX", status: "Active", division1: ["Division 1", "Division 2"], division2: ["Squad 1", "Squad 2"]}
   ])
   cert = Department.create({name: "Community Emergency Response Team",
+                            shortname: "CERT", 
                             status: "Active",
                             division1: ["Division 1", "Division 2"],
                             division2: ["Squad 1", "Squad 2"]})
   mrc = Department.create({name: "Medical Reserve Corp",
+                            shortname: "MRC",
                             status: "Active",
                             division1: ["Division 1", "Division 2"],
                             division2: ["Team 1", "Team 2"]})

--- a/spec/factories/departments.rb
+++ b/spec/factories/departments.rb
@@ -1,6 +1,7 @@
 FactoryGirl.define do
   factory :department do
     name "Red Cross"
+    shortname "Red Cross"
     status "Active"
     contact_id 1
     description "Large Organization"

--- a/spec/features/items_spec.rb
+++ b/spec/features/items_spec.rb
@@ -16,8 +16,8 @@ RSpec.describe Item do
   end
 
   it "a new item form with proper departments filled in" do
-    @department1 = Department.create(name: "Manages items", manage_items: true)
-    Department.create(name: "Doesn't manage items", manage_items: false)
+    @department1 = Department.create(name: "Manages items", shortname: "Manages items", manage_items: true)
+    Department.create(name: "Doesn't manage items", shortname: "Doesn't", manage_items: false)
     visit new_item_path
     expect(page).to have_select("item_department_id", :options => [@department1.name, ''])
   end

--- a/spec/features/person_creation_spec.rb
+++ b/spec/features/person_creation_spec.rb
@@ -24,32 +24,6 @@ RSpec.feature "Users can create new people" do
     expect(current_path).to eq root_path
   end
 
-  scenario "from the police people page" do
-    visit police_people_path
-    click_link "People"
-    click_link "New Person"
-    fill_in "First Name", with: "John"
-    fill_in "Last Name", with: "Doe"
-    fill_in "Date of birth", with: "1990-05-13"
-    select "Active", from: "person_status" #"Status" also matches Channel status
-    click_button "Create Person"
-    expect(page).to have_content "Person was successfully created."
-    expect(current_path).to eq police_people_path
-  end
-
-  scenario "from the CERT people page" do
-    visit cert_people_path
-    click_link "People"
-    click_link "New Person"
-    fill_in "First Name", with: "John"
-    fill_in "Last Name", with: "Doe"
-    fill_in "Date of birth", with: "1990-05-13"
-    select "Active", from: "person_status" #"Status" also matches Channel status
-    click_button "Create Person"
-    expect(page).to have_content "Person was successfully created."
-    expect(current_path).to eq cert_people_path
-  end
-
   scenario "from the everybody people page" do
     visit everybody_people_path
     click_link "People"

--- a/spec/features/person_displays_spec.rb
+++ b/spec/features/person_displays_spec.rb
@@ -5,9 +5,9 @@ RSpec.describe "Person" do
 
   describe "views" do
     before (:each) do
-      department_1 = create(:department, name: "Police")
-      department_2 = create(:department, name: "CERT")
-      department_3 = create(:department, name: "Other")
+      department_1 = create(:department, name: "Police", shortname: "Police")
+      department_2 = create(:department, name: "CERT", shortname: "CERT")
+      department_3 = create(:department, name: "Other", shortname: "Other")
       
       cj = create(:person, firstname: 'CJ',  department_id: department_1.id)
       cj.channels << create(:phone, channel_type: 'Phone', content: '9785551212', category: "Mobile Phone")
@@ -37,7 +37,7 @@ RSpec.describe "Person" do
     end
 
     it "returns a page for Police" do
-      visit police_people_path
+      visit department_people_path(Department.find_by(shortname: "Police").id)
       expect(page).to have_content('Police')
       expect(page).to have_content('Home') # This is in the nav bar
       expect(page).to have_content('CJ')
@@ -50,7 +50,7 @@ RSpec.describe "Person" do
    end
 
     it "returns a page for CERT" do
-      visit cert_people_path
+      visit department_people_path(Department.find_by(shortname: "CERT").id)
       expect(page).to have_content('CERT')
       expect(page).to have_content('Home') # This is in the nav bar
       expect(page).not_to have_content('CJ')

--- a/spec/views/departments/edit.html.erb_spec.rb
+++ b/spec/views/departments/edit.html.erb_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe "departments/edit", :type => :view do
   before(:each) do
     @department = assign(:department, Department.create!(
       :name => "MyString",
+      :shortname => "MyString",
       :status => "MyString",
       :contact_id => 1,
       :description => "MyText",

--- a/spec/views/departments/index.html.erb_spec.rb
+++ b/spec/views/departments/index.html.erb_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe "departments/index", :type => :view do
     assign(:departments, [
       Department.create!(
         :name => "Red Cross",
+        :shortname => "Red Cross",
         :status => "Active",
         :description => "MyText",
         :manage_people => false,
@@ -13,6 +14,7 @@ RSpec.describe "departments/index", :type => :view do
       ),
       Department.create!(
         :name => "MRC",
+        :shortname => "Red Cross",
         :status => "Active",
         :description => "MyText",
         :manage_people => true,

--- a/spec/views/departments/show.html.erb_spec.rb
+++ b/spec/views/departments/show.html.erb_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe "departments/show", :type => :view do
   before(:each) do
     @department = assign(:department, Department.create!(
       :name => "Name",
+      :shortname => "Name",
       :status => "Status",
       :contact_id => 1,
       :description => "MyText",


### PR DESCRIPTION
proof of concept for #231 - dynamic "People" submenu that is populated with departments that manage people. Replaces the hardcoded CERT and Police department routes.

There are still many places where department is treated as a string, but I thought I'd open this PR early to check if I understand the feature request.

UPDATE:
As requested, this PR also transitions to required department shortnames. The included migration should handle most cases without breaking anyone, and the seed.rb file has been updated accordingly.

![capture](https://cloud.githubusercontent.com/assets/222655/20952122/2ec692a4-bbf8-11e6-8ceb-65cd62f6d7b9.PNG)