### PR TITLE
Restore SSL ('https://rubygems.org') to Gemfile.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source 'http://rubygems.org'
+source 'https://rubygems.org'
 
 gem 'rails', '~> 4.2.7'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,5 +1,5 @@
 GEM
-  remote: http://rubygems.org/
+  remote: https://rubygems.org/
   remote: https://rails-assets.org/
   specs:
     actionmailer (4.2.7.1)


### PR DESCRIPTION
I believe the removal of SSL was a temporary workaround for a developer's local configuration issue, caused by Bundler making a puzzling SSL certificate change.  Removing SSL in the modern internet world isn't good practice; hopefully we can restore it now.