### PR TITLE
added Msg::Base#get_event_codename

### DIFF
--- a/app/services/msg/available.rb
+++ b/app/services/msg/available.rb
@@ -1,6 +1,7 @@
 class Msg::Available < Msg::Base
   def respond
-    case @params[:Body].split[1].downcase
+    codename = get_event_codename
+    case codename
     when "custom"
       begin
         # available custom 1/15/2017 0800 01/15/2021 Work
@@ -12,12 +13,12 @@ class Msg::Available < Msg::Base
       target = Event.new(start_time: start_time, end_time: end_time)
       description = @params[:Body].split[6..42].join(" ") if @params[:Body].split.size > 6
     else
-      target = Event.find_by_code(@params[:Body].split[1].downcase)
+      target = Event.find_by_code(codename)
       return target if target.is_a? Error::Base
       description = @params[:Body].split[2]
     end
 
-    # target = Notification::find_by_code.call(@params[:Body].split[1])
+    # target = Notification::find_by_code.call(codename)
     # TODO Need to verify and save Availabilites as needed.
 
     Availability.create(person: @person,

--- a/app/services/msg/base.rb
+++ b/app/services/msg/base.rb
@@ -4,4 +4,11 @@ class Msg::Base
     @params = args[:params]
   end
 
+  def get_event_codename
+    if @params.has_key?(:Body) and @params[:Body].present?
+      return @params[:Body].split[1].downcase
+    end
+    nil
+  end
+
 end

--- a/app/services/msg/unavailable.rb
+++ b/app/services/msg/unavailable.rb
@@ -1,6 +1,7 @@
 class Msg::Unavailable < Msg::Base
   def respond
-    case @params[:Body].split[1].downcase
+    codename = get_event_codename
+    case codename
     when "custom"
       begin
         # available custom 1/15/2017 0800 01/15/2021 Work
@@ -12,7 +13,7 @@ class Msg::Unavailable < Msg::Base
       target = Event.new(start_time: start_time, end_time: end_time)
       description = @params[:Body].split[6..42].join(" ") if @params[:Body].split.size > 6
     else
-      target = Event.find_by_code(@params[:Body].split[1].downcase)
+      target = Event.find_by_code(codename)
       return target if target.is_a? Error::Base
       description = @params[:Body].split[2]
     end

--- a/spec/services/msg/base_spec.rb
+++ b/spec/services/msg/base_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+RSpec.describe Msg::Base do
+  describe "extracting event codename" do
+    it "should extract it when present" do
+      base_msg = Msg::Base.new({params: {Body: "foo\ncodename"}})
+      expect(base_msg.get_event_codename).to eq("codename")
+    end
+    it "should downcase the event codename" do
+      base_msg = Msg::Base.new({params: {Body: "foo\nCoDenaMe"}})
+      expect(base_msg.get_event_codename).to eq("codename")
+    end
+    
+    it "should return nil when not present" do
+      base_msg = Msg::Base.new({params: {}})
+      expect(base_msg.get_event_codename).to eq(nil)
+      base_msg = Msg::Base.new({params: {Body: nil}})
+      expect(base_msg.get_event_codename).to eq(nil)
+    end
+  end
+end


### PR DESCRIPTION
* adds a helper method to make it easy and obvious to extract event codenames
from params.
* refactored available and unavailable to use it
* added spec for new method