### PR TITLE
[304] Event#upcoming should not show events from the past

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -28,7 +28,7 @@ class Event < ActiveRecord::Base
   accepts_nested_attributes_for :timecards
   accepts_nested_attributes_for :certs
 
-  scope :upcoming, -> { order("start_time ASC").where( status: ["Scheduled", "In-session"] ) }
+  scope :upcoming, -> { order("start_time ASC").where( "status in (?) AND end_time < ?", ["Scheduled", "In-session"], Time.now ) }
 
   CATEGORY_CHOICES = ['Training', 'Patrol', 'Meeting', 'Admin', 'Event', 'Template']
   STATUS_CHOICES = ['Scheduled', 'In-session', 'Completed', 'Cancelled', "Closed"]


### PR DESCRIPTION
	modified:   app/models/event.rb