### PR TITLE
fix db/seeds and _coc_boxes partial

### DIFF
--- a/app/views/people/_coc_boxes.html.erb
+++ b/app/views/people/_coc_boxes.html.erb
@@ -1,4 +1,4 @@
-<li class="<%= h p.title.downcase.split(" ")[0] -%>">
+<li class="<%= h p.title.to_s.downcase.split(" ")[0] -%>">
 	<%= h p.shortrank -%>
 	<%= h p.firstname[0] + " " + p.lastname -%> (<%= h p.icsid -%>)<br/>
 	<%#= number_to_phone(p.contacts.first.content, :area_code => true) +    " " + p.contacts.first.category.split(" ")[0] if p.contacts.first -%>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -78,8 +78,7 @@ Location.create([
   {name: "Building 2", status: "Active",
     department: Department.where(name: "Department Public Works").first },
   {name: "Inactive Location", status: "Inactive",
-    department: Department.where(name: "Department Public Works").first },
-  }
+    department: Department.where(name: "Department Public Works").first }
   ])
 
 # After we create ResourceTypes, we can create Items


### PR DESCRIPTION
I discovered these issues while starting on https://github.com/ReadyResponder/ReadyResponder/issues/293 :
* db/seeds.rb file has syntax errors, possibly from a bad merge
* orgchart page doesnt render if any `person#title` is nil.

I also realized it wasn't clear to me what "Org Chart menu choices" refers to. Opening PR in this branch for minor fixes while I await clarification. 