### PR TITLE
fix Event.upcoming

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -28,7 +28,7 @@ class Event < ActiveRecord::Base
   accepts_nested_attributes_for :timecards
   accepts_nested_attributes_for :certs
 
-  scope :upcoming, -> { order("start_time ASC").where( "status in (?) AND end_time < ?", ["Scheduled", "In-session"], Time.now ) }
+  scope :upcoming, -> { order("start_time ASC").where( "status in (?) AND end_time > ?", ["Scheduled", "In-session"], Time.now ) }
 
   CATEGORY_CHOICES = ['Training', 'Patrol', 'Meeting', 'Admin', 'Event', 'Template']
   STATUS_CHOICES = ['Scheduled', 'In-session', 'Completed', 'Cancelled', "Closed"]

--- a/spec/features/notifications_spec.rb
+++ b/spec/features/notifications_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe "Notifications" do
 
     context "from an event" do
       let!(:event)  { create(:event) }
-      pending "should create a notification for that event" do
+      it "should create a notification for that event" do
         allow_any_instance_of(Notification).to receive(:activate!).and_return(nil)
         visit event_path(event)
         expect(page).to have_content('Description:')

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -53,6 +53,10 @@ RSpec.describe Event do
     @event = build(:event, start_time: Time.current, end_time: 75.minutes.from_now, status: "Closed")
     expect(@event.ready_to_schedule?("Scheduled")).to eq(false)  #Never for a closed event
   end
+  it "counts as upcoming if it hasnt ended" do
+    @event = create(:event, start_time: Time.current, end_time: 75.minutes.from_now, status: "Scheduled")
+    expect(Event.upcoming.include?(@event)).to be(true)
+  end
 
   it "always fails" do
     #1.should eq(2)


### PR DESCRIPTION
Unfortunately the logic for `Event#upcoming` appears to have been reversed. I believe this change was introduced in https://github.com/ReadyResponder/ReadyResponder/pull/312 

Behavior in development branch: `Event.upcoming` returns events that have already ended
Behavior in this PR: `Event.upcoming` returns events that have not yet ended

This also fixes the "unrelated" notification spec failure in https://github.com/ReadyResponder/ReadyResponder/pull/315 , https://github.com/ReadyResponder/ReadyResponder/pull/323 and https://github.com/ReadyResponder/ReadyResponder/pull/324 because the "new notification" form populates dropdowns with "upcoming" events.