### PR TITLE
Omit title object from new title route path

### DIFF
--- a/app/views/titles/show.html.erb
+++ b/app/views/titles/show.html.erb
@@ -2,7 +2,7 @@
   <h2>Title<br/><%= @title.name %></h2>
   <%= sidebar_button_link 'Edit', edit_title_path(@title) %>
   <%#= sidebar_button_link 'Destroy', @skill, method: :delete %>
-  <%= sidebar_button_link 'New Title', new_title_path(@title) if can? :create, Title %>
+  <%= sidebar_button_link 'New Title', new_title_path if can? :create, Title %>
   <%= sidebar_button_link 'Titles Listing', titles_path %>
 <% end %>
 


### PR DESCRIPTION
Because the route for `new_title_path` doesn't expect an id to be a part
of it, it's treating the passed object as an indicator of the view
rendering format (e.g. html, json, etc.). We also just don't need the
object at all.

Fixes #316.