### PR TITLE
Availability sets older duplicates to Cancelled, fixes #372

### DIFF
--- a/app/models/availability.rb
+++ b/app/models/availability.rb
@@ -48,7 +48,7 @@ class Availability < ActiveRecord::Base
     previous_availabilities = person.availabilities.for_time_span(start_time..end_time).order(:created_at)
     previous_availabilities.each do |a|
       if start_time == a.start_time && end_time == a.end_time
-        a.update(status: "Cancelled")
+        a.update(status: "Cancelled") unless self == a
       end
     end
   end

--- a/app/models/availability.rb
+++ b/app/models/availability.rb
@@ -1,7 +1,7 @@
 class Availability < ActiveRecord::Base
   belongs_to :person
 
-  before_create :cancel_duplicates
+  after_create :cancel_duplicates
 
   validates_presence_of :person, :status, :start_time, :end_time
   validates_chronology :start_time, :end_time

--- a/spec/models/availability_spec.rb
+++ b/spec/models/availability_spec.rb
@@ -34,4 +34,16 @@ RSpec.describe Availability, type: :model do
       expect(availability.partially_available?(event)).to eq(false)
     end
   end
+
+  context 'cancel_duplicates' do
+    it 'sets status for previous availabilities with matching start and end times to Cancelled' do
+      start_time = Time.now
+      end_time = start_time + 2.minutes
+      first_availability = create(:availability, person: a_person, start_time: start_time, end_time: end_time, created_at: Time.now - 2.minutes)
+      second_availability = create(:availability, person: a_person, start_time: start_time, end_time: end_time)
+
+      expect(first_availability.reload.status).to eq('Cancelled')
+      expect(second_availability.status).to eq('Unavailable')
+    end
+  end
 end

--- a/spec/models/availability_spec.rb
+++ b/spec/models/availability_spec.rb
@@ -39,10 +39,11 @@ RSpec.describe Availability, type: :model do
     it 'sets status for previous availabilities with matching start and end times to Cancelled' do
       start_time = Time.now
       end_time = start_time + 2.minutes
-      first_availability = create(:availability, person: a_person, start_time: start_time, end_time: end_time, created_at: Time.now - 2.minutes)
+      first_availability = create(:availability, person: a_person, start_time: start_time, end_time: end_time)
       second_availability = create(:availability, person: a_person, start_time: start_time, end_time: end_time)
 
-      expect(first_availability.reload.status).to eq('Cancelled')
+      first_availability = first_availability.reload
+      expect(first_availability.status).to eq('Cancelled')
       expect(second_availability.status).to eq('Unavailable')
     end
   end


### PR DESCRIPTION
This method naively compares start and end times.

I can have it round to the closest 1/4 hour but I wasn't sure if we have an abstraction for rounding of time we're using in the project.

Can easily implement that in the method, or just do the rounding in the method itself, whatever you prefer.