### PR TITLE
remove 'Template' from CATEGORY_CHOICES in event.rb

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -32,7 +32,7 @@ class Event < ActiveRecord::Base
     ["Scheduled", "In-session"], Time.now )
   }
 
-  CATEGORY_CHOICES = ['Training', 'Patrol', 'Meeting', 'Admin', 'Event', 'Template']
+  CATEGORY_CHOICES = ['Training', 'Patrol', 'Meeting', 'Admin', 'Event']
   STATUS_CHOICES = ['Scheduled', 'In-session', 'Completed', 'Cancelled', "Closed"]
 
   def to_s


### PR DESCRIPTION
Fix bug removing 'Template' from category choices

-  Removed 'Template' as an option from the CATEGORY_CHOICES constant in the 
   event model.