### PR TITLE
alter columns  on tasks table

### DIFF
--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -1,5 +1,7 @@
 class Notification < ActiveRecord::Base
 #  serialize :departments, Array
+  has_paper_trail
+
   has_and_belongs_to_many :departments
   belongs_to :event
   has_many :recipients

--- a/app/views/tasks/_tasks_table.html.erb
+++ b/app/views/tasks/_tasks_table.html.erb
@@ -2,10 +2,10 @@
   <thead>
     <tr>
       <th>Title</th>
-      <th>Priority</th>
       <th>Assignees</th>
+      <th>Priority</th>
       <th>Status</th>
-      <th>Requirements Met</th>
+      <th>Reqs</th>
       <th>Start Time</th>
       <th>End Time</th>
       <th></th>
@@ -15,8 +15,8 @@
     <% tasks.each do |task| %>
       <tr <%== task_status_class(task) %>>
         <td><%= link_to task.title, task %></td>
-        <td <%== sorting_order(task.priority) %>><%= task_priority_label(task) %></td>
         <td><ol><%= render partial: "assignee", collection: task.assignees %></ol></td>
+        <td <%== sorting_order(task.priority) %>><%= task_priority_label(task) %></td>
         <td <%== sorting_order(task.staffing_value) %>><%= task_staffing_label(task) %></td>
         <td><%= task.requirements_met_count %>/<%= task.requirements_count %></td>
         <td><%= task.start_time.strftime('%a %b %d %k:%M') if task.start_time %></td>

--- a/spec/features/notifications_spec.rb
+++ b/spec/features/notifications_spec.rb
@@ -5,8 +5,7 @@ RSpec.describe "Notifications" do
     before (:each) { sign_in_as('Editor') }
     let!(:notification)  { create(:notification, subject: "Howdy from Hopedale") }
     context "basic CRUD" do
-      let!(:notification)  { create(:notification, subject: "Howdy from Hopedale") }
-      it "should display one at a time" do
+      it "should display a single notification" do
         visit notification_path(notification)
         expect(page).to have_content("Howdy")
       end

--- a/spec/features/notifications_spec.rb
+++ b/spec/features/notifications_spec.rb
@@ -3,7 +3,14 @@ require 'rails_helper'
 RSpec.describe "Notifications" do
   describe " visit notifications" do
     before (:each) { sign_in_as('Editor') }
-
+    let!(:notification)  { create(:notification, subject: "Howdy from Hopedale") }
+    context "basic CRUD" do
+      let!(:notification)  { create(:notification, subject: "Howdy from Hopedale") }
+      it "should display one at a time" do
+        visit notification_path(notification)
+        expect(page).to have_content("Howdy")
+      end
+    end
     context "from an event" do
       let!(:event)  { create(:event) }
       it "should create a notification for that event" do
@@ -22,5 +29,6 @@ RSpec.describe "Notifications" do
           expect(page).to have_content "Notification was successfully created."
         end
       end
-    end  end
+    end
+  end
 end


### PR DESCRIPTION
reorder priority to be after assignees and shortened "Requirements Met" to "Reqs" 