### PR TITLE
requirements now skill OR title enforced

### DIFF
--- a/app/models/requirement.rb
+++ b/app/models/requirement.rb
@@ -11,6 +11,7 @@ class Requirement < ActiveRecord::Base
   # validates :skill, presence: title.blank?
   # validates :title, presence: skill.blank?
   validate  :valid_title_or_skill
+  # ^^^ guarantees one or the other has been set (not both)
 
   validates :minimum_people, presence: true, numericality: { only_integer: true, greater_than_or_equal_to: 0 }
   validates :maximum_people, presence: true, numericality: { only_integer: true, greater_than_or_equal_to: 0 }
@@ -91,6 +92,10 @@ class Requirement < ActiveRecord::Base
       if title.blank? && skill.blank?
         errors.add(:title, "must have a title or a skill")
         errors.add(:skill, "must have a title or a skill")
+      end
+      if title.present? && skill.present?
+        errors.add(:title, "must have only a title or a skill")
+        errors.add(:skill, "must have only a title or a skill")
       end
     end
 end

--- a/spec/models/requirement_spec.rb
+++ b/spec/models/requirement_spec.rb
@@ -9,6 +9,8 @@ RSpec.describe Requirement, type: :model do
     # expect(build_stubbed(:requirement)).to be_valid
     expect(build_stubbed(:requirement, task: a_task, skill: a_skill)).to be_valid
     expect(build_stubbed(:requirement, task: a_task, title: a_title)).to be_valid
+    expect(build_stubbed(:requirement, task: a_task, title: a_title,
+                         skill: a_skill)).to_not be_valid
   end
 
   context 'validations' do


### PR DESCRIPTION
requirements should only be allowed to have a skill or a title but not both. The UI enforced this. The code did not.