### PR TITLE
Issue #395: Fix start time sorting for availabilities on Person#show

### DIFF
--- a/app/views/availabilities/_availabilities_table_for_people.html.erb
+++ b/app/views/availabilities/_availabilities_table_for_people.html.erb
@@ -11,7 +11,7 @@
     <% availabilities.each do |a| %>
     <tr <%== availability_status_class(a) %> >
         <td><%= link_to availability_status_label(a), availability_path(a) %></td>
-        <td><time><%= a.start_time %></time></td>
+        <td><%= a.start_time %></td>
         <td><%= a.end_time %></td>
         <td><%= truncate(a.description, length: 24) %></td>
       </tr>

--- a/spec/support/database_cleaner.rb
+++ b/spec/support/database_cleaner.rb
@@ -1,8 +1,8 @@
 RSpec.configure do |config|
 
   config.before(:suite) do
-    DatabaseCleaner.strategy = :deletion
-    DatabaseCleaner.clean_with(:truncation)
+    DatabaseCleaner.strategy = :truncation
+    DatabaseCleaner.clean
   end
 
   config.around(:each) do |example|


### PR DESCRIPTION
Addressing Issue #395 

Remove the unnecessary `<time>` tag from around start times in the
availability table on the Person#show page. This was causing the sorting
functionality in the datatable to misinterpret start time values and
sort alphabetically instead of by time.

I also ran into some FK failures in the test suite, and switched the
database cleaner strategy to truncation. In my experience truncation is
a quicker and more effective approach to use, and switching it resolved
the test suite issues I was seeing.