### PR TITLE
Item belongs_to grant migrations and CRUD interface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@
 *~
 *.kate-swp
 /public/uploads
+*.DS_Store
 
 # Ignore database settings
 /config/database.yml

--- a/app/controllers/grants_controller.rb
+++ b/app/controllers/grants_controller.rb
@@ -21,7 +21,7 @@ class GrantsController < ApplicationController
   end
 
   def create
-    @grant = Grant.new(grant_params)
+    @grant = Grant.new(params[:grant])
 
     if @grant.save
       redirect_to @grant, notice: 'Grant was successfully created.'

--- a/app/controllers/grants_controller.rb
+++ b/app/controllers/grants_controller.rb
@@ -1,0 +1,52 @@
+class GrantsController < ApplicationController
+  before_filter :authenticate_user!
+  load_and_authorize_resource
+
+  def index
+    @grants = Grant.all
+    @page_title = "All Grants"
+  end
+
+  def show
+    @page_title = "Grant: #{@grant.name}"
+  end
+
+  def new
+    @grant = Grant.new
+    @page_title = "New Grant"
+  end
+
+  def edit
+    @page_title = "Grant: #{@grant.name}"
+  end
+
+  def create
+    @grant = Grant.new(grant_params)
+
+    if @grant.save
+      redirect_to @grant, notice: 'Grant was successfully created.'
+    else
+      render action: "new"
+    end
+  end
+
+  def update
+    if @grant.update_attributes(grant_params)
+      redirect_to @grant, notice: 'Grant was successfully updated.'
+    else
+      render action: "edit"
+    end
+  end
+
+  def destroy
+    @grant.destroy
+    redirect_to grants_path
+  end
+
+  private
+
+  def grant_params
+    params.require(:grant).permit(:name, :description, :start_date, :end_date)
+  end
+
+end

--- a/app/controllers/grants_controller.rb
+++ b/app/controllers/grants_controller.rb
@@ -46,7 +46,7 @@ class GrantsController < ApplicationController
   private
 
   def grant_params
-    params.require(:grant).permit(:name, :description, :start_date, :end_date)
+    params.require(:grant).permit(:name, :description, :start_date, :end_date, :status)
   end
 
 end

--- a/app/helpers/grants_helper.rb
+++ b/app/helpers/grants_helper.rb
@@ -1,0 +1,10 @@
+module GrantsHelper
+
+  def edit_grant_button
+    return nil if cannot? :edit, @grant
+    return link_to "Edit",
+                   edit_grant_path(@grant),
+                   class: 'btn btn-block btn-primary'
+  end
+
+end

--- a/app/models/grant.rb
+++ b/app/models/grant.rb
@@ -1,3 +1,17 @@
 class Grant < ActiveRecord::Base
   has_many :items
+
+  validate :end_date_after_start_date?
+
+  scope :active, -> { where(status: "Active") }
+
+  STATUS_CHOICES = [ "Active", "Expired" ]
+
+  private
+
+  def end_date_after_start_date?
+    if end_date < start_date
+      errors.add :end_date, "must be after start date"
+    end
+  end
 end

--- a/app/models/grant.rb
+++ b/app/models/grant.rb
@@ -1,0 +1,3 @@
+class Grant < ActiveRecord::Base
+  has_many :items
+end

--- a/app/models/grant.rb
+++ b/app/models/grant.rb
@@ -1,7 +1,9 @@
 class Grant < ActiveRecord::Base
-  has_many :items
+  attr_accessible :name, :description, :start_date, :end_date, :status
 
   validate :end_date_after_start_date?
+
+  has_many :items
 
   scope :active, -> { where(status: "Active") }
 

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -24,6 +24,7 @@ class Item < ActiveRecord::Base
   belongs_to :location
   belongs_to :department
   belongs_to :item_type
+  belongs_to :grant
   has_many :repairs
   has_many :inspections
   has_many :unique_ids

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -7,7 +7,7 @@ class Item < ActiveRecord::Base
                   :sell_amt, :sell_date, :stock_number,
                   :source, :status, :condition, :comments, :item_image,
                   :department_id, :resource_type_id, :item_type_id,
-                  :unique_ids_attributes
+                  :unique_ids_attributes, :grant_id
 
   # validates_chronology :purchase_date, :sell_date     # ? - if so, needs a test
   # validates_chronology :grantstart, :grantexpiration  # ? - if so, needs a test
@@ -24,7 +24,7 @@ class Item < ActiveRecord::Base
   belongs_to :location
   belongs_to :department
   belongs_to :item_type
-  belongs_to :grant
+  belongs_to :grantor, foreign_key: :grant_id, class_name: 'Grant'
   has_many :repairs
   has_many :inspections
   has_many :unique_ids

--- a/app/views/grants/_form.html.erb
+++ b/app/views/grants/_form.html.erb
@@ -1,0 +1,20 @@
+<%= simple_form_for @grant, :html => {:multipart => true} do |f| %>
+  <%= f.error_notification %>
+
+  <div class="form-inputs">
+    <%= f.input :name, :value => f.object.name %>
+    <%= f.input :description, :value => f.object.description %>
+    <%= f.input :start_date, as: :string,
+                input_html: { class: 'datepicker', size: 11,
+                              value: format_date_value(f.object.start_date) } %>
+    <%= f.input :end_date, as: :string,
+                input_html: { class: 'datepicker', size: 11,
+                              value: format_date_value(f.object.end_date) } %>
+  </div>
+
+  <br/>
+
+  <div class="form-actions">
+    <%= f.button :submit %>
+  </div>
+<% end %>

--- a/app/views/grants/_form.html.erb
+++ b/app/views/grants/_form.html.erb
@@ -10,6 +10,7 @@
     <%= f.input :end_date, as: :string,
                 input_html: { class: 'datepicker', size: 11,
                               value: format_date_value(f.object.end_date) } %>
+    <%= f.input :status, :as => :select, :collection => Grant::STATUS_CHOICES %>
   </div>
 
   <br/>

--- a/app/views/grants/edit.html.erb
+++ b/app/views/grants/edit.html.erb
@@ -1,0 +1,6 @@
+<% content_for :sidebar do %>
+  <h1>Editing Grant</h1>
+  <%= sidebar_button_link 'Cancel', grant_path(@grant) %>
+<% end %>
+
+<%= render 'form' %>

--- a/app/views/grants/index.html.erb
+++ b/app/views/grants/index.html.erb
@@ -9,6 +9,7 @@
       <th>Name</th>
       <th>Start Date</th>
       <th>End Date</th>
+      <th>Status</th>
       <th>Number of Items</th>
       <th></th>
     </tr>
@@ -17,8 +18,9 @@
     <% @grants.each do |g| %>
       <tr>
         <td><%= link_to g.name, grant_path(g) %></td>
-        <td><%= g.start_date %></td>
-        <td><%= g.end_date %></td>
+        <td><%= g.start_date.try(:to_date) %></td>
+        <td><%= g.end_date.try(:to_date) %></td>
+        <td><%= g.status %></td>
         <td><%= g.items.count %></td>
         <td><%= table_button_link 'Edit', edit_grant_path(g) unless cannot? :edit, Grant %></td>
       </tr>

--- a/app/views/grants/index.html.erb
+++ b/app/views/grants/index.html.erb
@@ -1,0 +1,27 @@
+<% content_for :sidebar do %>
+  <%= sidebar_button_link 'New Grant', new_grant_path if can? :create, Grant %>
+<% end %>
+
+<table id="grants" class="datatable table table-striped table-bordered" >
+  <caption><h3><%= @page_title %></h3></caption>
+  <thead>
+    <tr>
+      <th>Name</th>
+      <th>Start Date</th>
+      <th>End Date</th>
+      <th>Number of Items</th>
+      <th></th>
+    </tr>
+  </thead>
+  <tbody>
+    <% @grants.each do |g| %>
+      <tr>
+        <td><%= link_to g.name, grant_path(g) %></td>
+        <td><%= g.start_date %></td>
+        <td><%= g.end_date %></td>
+        <td><%= g.items.count %></td>
+        <td><%= table_button_link 'Edit', edit_grant_path(g) unless cannot? :edit, Grant %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/grants/new.html.erb
+++ b/app/views/grants/new.html.erb
@@ -1,0 +1,6 @@
+<% content_for :sidebar do %>
+  <h1>New Grant</h1>
+  <%= sidebar_button_link 'Cancel', grants_path %>
+<% end %>
+
+<%= render 'form' %>

--- a/app/views/grants/show.html.erb
+++ b/app/views/grants/show.html.erb
@@ -1,0 +1,29 @@
+<% content_for :sidebar do %>
+  <%= edit_grant_button %>
+<% end %>
+
+<h3>
+  <%= link_to 'Grants', grants_path %> >
+  <%= @grant.name %>
+</h3>
+<hr/>
+
+<% if @grant.description.present? %>
+  <p><b>Description:</b> <%= @grant.description %></p>
+<% end %>
+
+<% if @grant.start_date.present? %>
+  <p><b>Start date:</b> <%= @grant.start_date %></p>
+<% end %>
+
+<% if @grant.end_date.present? %>
+  <p><b>End date:</b> <%= @grant.end_date %></p>
+<% end %>
+
+<p><b>Grant Items:</b></p>
+<% if @grant.items.present? %>
+  <%= render partial: 'items/items_table', locals: { items: @grant.items } %>
+<% else %>
+  <p>Not Available</p>
+<% end %>
+

--- a/app/views/grants/show.html.erb
+++ b/app/views/grants/show.html.erb
@@ -20,6 +20,8 @@
   <p><b>End date:</b> <%= @grant.end_date %></p>
 <% end %>
 
+<p><b>Status:</b> <%= @grant.status.presence || 'N/A' %></p>
+
 <p><b>Grant Items:</b></p>
 <% if @grant.items.present? %>
   <%= render partial: 'items/items_table', locals: { items: @grant.items } %>

--- a/app/views/items/_form.html.erb
+++ b/app/views/items/_form.html.erb
@@ -19,6 +19,7 @@
     <%= f.input :po_number %>
     <%= f.input :value, :placeholder => 'Replacement price' %>
     <%= f.input :grant, :placeholder => 'Grant name, if applicable' %>
+    <%= f.input :grant_id, label: 'Granted by', :as => :select, :collection => Grant.active %>
     <%= f.input :purchase_date, as: :string,
                 input_html: { class: 'datepicker', size: 11,
                               value: format_date_value(f.object.purchase_date) } %>

--- a/app/views/layouts/_top_menu.html.erb
+++ b/app/views/layouts/_top_menu.html.erb
@@ -53,6 +53,7 @@
               <%= nav_link "Locations", locations_path if can? :read, Location %>
               <%= nav_link "Resource Types", resource_types_path if can? :read, ResourceType%>
               <%= nav_link "Item Types", item_types_path if can? :read, ItemType %>
+              <%= nav_link "Grants", grants_path if can? :read, Grant %>
               <%= nav_link "Users", users_path if can? :read, User %>
               <%= nav_link "Settings", settings_path if can? :read, Setting %>
             </ul>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -42,7 +42,7 @@ Rails.application.routes.draw do
   resources :channels
   resources :departments
   resources :timecards
-  
+
   resources :timecards do
     post 'verify'
   end
@@ -63,6 +63,7 @@ Rails.application.routes.draw do
     resources :repairs
     resources :inspections, only: [:new, :create]
   end
+  resources :grants
 
   get '/uploads/item/item_image/:id/:basename.:extension', controller: 'items', action: 'download', type: 'item_image'
   get '/uploads/item_type/item_type_image/:id/:basename.:extension', controller: 'item_types', action: 'download', type: 'item_type_image'

--- a/db/migrate/20171002062634_create_grants.rb
+++ b/db/migrate/20171002062634_create_grants.rb
@@ -1,0 +1,10 @@
+class CreateGrants < ActiveRecord::Migration
+  def change
+    create_table :grants do |t|
+      t.string :name
+      t.text :description
+      t.datetime :start_date
+      t.datetime :end_date
+    end
+  end
+end

--- a/db/migrate/20171002062903_add_grant_id_to_items.rb
+++ b/db/migrate/20171002062903_add_grant_id_to_items.rb
@@ -1,0 +1,5 @@
+class AddGrantIdToItems < ActiveRecord::Migration
+  def change
+    add_column :items, :grant_id, :integer
+  end
+end

--- a/db/migrate/20171002095035_add_status_to_grants.rb
+++ b/db/migrate/20171002095035_add_status_to_grants.rb
@@ -1,0 +1,5 @@
+class AddStatusToGrants < ActiveRecord::Migration
+  def change
+    add_column :grants, :status, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170910011230) do
+ActiveRecord::Schema.define(version: 20171002062903) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -171,6 +171,13 @@ ActiveRecord::Schema.define(version: 20170910011230) do
     t.integer  "template_id"
   end
 
+  create_table "grants", force: :cascade do |t|
+    t.string   "name"
+    t.text     "description"
+    t.datetime "start_date"
+    t.datetime "end_date"
+  end
+
   create_table "helpdocs", force: :cascade do |t|
     t.string   "title"
     t.text     "contents"
@@ -259,6 +266,7 @@ ActiveRecord::Schema.define(version: 20170910011230) do
     t.integer  "item_type_id"
     t.string   "condition"
     t.integer  "qty"
+    t.integer  "grant_id"
   end
 
   create_table "locations", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171002062903) do
+ActiveRecord::Schema.define(version: 20171002095035) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -176,6 +176,7 @@ ActiveRecord::Schema.define(version: 20171002062903) do
     t.text     "description"
     t.datetime "start_date"
     t.datetime "end_date"
+    t.string   "status"
   end
 
   create_table "helpdocs", force: :cascade do |t|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -103,6 +103,13 @@ ht = ItemType.find_or_create_by(name: "Radio, Portable") do |item_type|
   item_type.description = "Handheld radios"
 end
 
+tmp_grant = Grant.find_or_create_by(name: "foo-grant") do |grant|
+  grant.description = "Donated a collection of 200 books by XYZ publications"
+  grant.start_date = '12-12-2012'
+  grant.start_date = '10-10-2017'
+  grant.status = 'Active'
+end
+
 Item.find_or_create_by(name: "Radio 1") do |item|
   item.item_type = ht
   item.department = mrc
@@ -112,4 +119,5 @@ Item.find_or_create_by(name: "Radio 1") do |item|
   item.brand = "Motorola"
   item.model = "HT-1000"
   item.qty = 1
+  item.grant_id = tmp_grant.id
 end

--- a/spec/factories/grant.rb
+++ b/spec/factories/grant.rb
@@ -1,0 +1,8 @@
+FactoryGirl.define do
+  factory :grant do
+    name "BIG_GRANT"
+    description "big grant from XYZ corp"
+    start_date "2015-10-11"
+    end_date "2017-02-03"
+  end
+end

--- a/spec/features/grants_spec.rb
+++ b/spec/features/grants_spec.rb
@@ -1,0 +1,52 @@
+require 'rails_helper'
+
+RSpec.describe Grant do
+  before(:each) do
+    sign_in_as('Manager')
+  end
+
+  context "NEW Grant" do
+    before do
+      visit new_grant_path
+    end
+
+    it "a new grant form with appropriate fields" do
+      expect(page).to have_field('grant_name')
+      expect(page).to have_field('grant_description')
+      expect(page).to have_field('grant_start_date')
+      expect(page).to have_field('grant_end_date')
+    end
+
+    it "create new grant" do
+      fill_in('grant_name', :with => 'foo')
+      fill_in('grant_description', :with => 'bar')
+      fill_in('grant_start_date', :with => '10-10-2010')
+      fill_in('grant_end_date', :with => '10-10-2012')
+      click_button('Create Grant')
+
+      expect(Grant.last.name).to eq('foo')
+    end
+  end
+
+  context "EDIT Grant" do
+    before do
+      @grant = create(:grant)
+      visit edit_grant_path(@grant)
+    end
+
+    it "edit page should have appropriate fields" do
+      expect(page).to have_field('grant_name')
+      expect(page).to have_field('grant_description')
+      expect(page).to have_field('grant_start_date')
+      expect(page).to have_field('grant_end_date')
+    end
+
+    it "successful edit should update data in grants table" do
+      fill_in('grant_name', :with => 'foo update')
+      click_button('Update Grant')
+
+      expect(Grant.last.name).to eq('foo update')
+    end
+  end
+
+end

--- a/spec/models/grant_spec.rb
+++ b/spec/models/grant_spec.rb
@@ -1,0 +1,11 @@
+require 'rails_helper'
+
+RSpec.describe Grant do
+  context "associations" do
+    it { is_expected.to have_many(:items) }
+  end
+
+  it "has a valid factory" do
+    expect(create(:grant)).to be_valid
+  end
+end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -1,6 +1,10 @@
 require 'rails_helper'
 
 RSpec.describe Item do
+  context "associations" do
+    it { is_expected.to belong_to(:grant) }
+  end
+
   it "has a valid factory" do
     expect(create(:item)).to be_valid
   end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe Item do
   context "associations" do
-    it { is_expected.to belong_to(:grant) }
+    it { is_expected.to belong_to(:grantor) }
   end
 
   it "has a valid factory" do


### PR DESCRIPTION
resolves #84

PR includes:
- new model `Grant` is created along with db migrations
- added CRUD interface for Grant model (GUI navigation from top bar Admin drop -> Grants)
- added Item `belongs_to` Grant association with key word `grantor` (there was already a column named 'grant' in `items` table): `Item.last.grantor` gives associated model 
- updated `db/seeds.rb` with new model content 
- added model and feature specs for sections that was worked on
