### PR TITLE
Add inspection_questions association

### DIFF
--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -27,6 +27,7 @@ class Item < ActiveRecord::Base
   belongs_to :grantor, foreign_key: :grant_id, class_name: 'Grant'
   has_many :repairs
   has_many :inspections
+  has_many :inspection_questions, through: :inspections
   has_many :unique_ids
 
   delegate :item_category, :to => :item_type

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -1,11 +1,10 @@
 require 'rails_helper'
 
 RSpec.describe Item do
-  context "associations" do
-    it { is_expected.to belong_to(:grantor) }
-  end
+  it { is_expected.to belong_to(:grantor) }
+  it { is_expected.to have_many(:inspection_questions).through(:inspections) }
 
-  it "has a valid factory" do
+  it 'has a valid factory' do
     expect(create(:item)).to be_valid
   end
 end


### PR DESCRIPTION
Issue: https://github.com/ReadyResponder/ReadyResponder/issues/487

Changes:

  * Adds the `inspection_questions` association to `Item`