### PR TITLE
Validate application_date <= start_date (issue #313)

### DIFF
--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -36,6 +36,8 @@ class Person < ActiveRecord::Base
   validates_presence_of :division1, :unless => "division2.blank?"
   validates_chronology :start_date, :end_date
 
+  validate :start_date_cannot_be_before_application_date
+
   scope :cert, -> { order("division1, division2, title_order, start_date ASC").where( department: "CERT" ) }
   scope :police, -> { order("division1, division2, title_order, start_date ASC").where( department: "Police" ) }
   scope :leave, -> { where( status: "Leave of Absence" ) }
@@ -196,6 +198,16 @@ class Person < ActiveRecord::Base
       else
         Date.today.year - self.start_date.year + ( self.start_date.yday < Date.today.yday ? 1 : 0 )
       end
+    end
+  end
+
+  private
+
+  def start_date_cannot_be_before_application_date
+    return unless start_date && application_date
+
+    if start_date < application_date
+      errors.add(:start_date, "cannot be before the application date")
     end
   end
 end

--- a/spec/features/person_creation_spec.rb
+++ b/spec/features/person_creation_spec.rb
@@ -26,4 +26,23 @@ RSpec.feature "Users can create new people" do
     expect(current_path).to eq everybody_people_path
   end
 
+
+  scenario "when user-entered start date is before the applicaton date" do
+    visit everybody_people_path
+
+    click_link "People"
+    click_link "New Person"
+
+    fill_in "First Name", with: "G.I."
+    fill_in "Last Name", with: "Joe"
+    select "Active", from: "person_status"
+
+    fill_in "Start date", with: "2017-01-01"
+    fill_in "Application date", with: "2017-12-01"
+
+    click_button "Create Person"
+    expect(page).to have_content "Start date cannot be before the application date"
+
+    expect(page).not_to have_content "Person was sucessfully created"
+  end
 end

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe Person do
       let(:person) { build :person, start_date: start_date, application_date: application_date }
 
       context "when the start date is not present" do
-        let!(:application_date) { Date.today }
+        let!(:application_date) { Time.zone.today }
         let!(:start_date) { nil }
 
         it "is a valid person" do
@@ -41,7 +41,7 @@ RSpec.describe Person do
 
       context "when the application date is not present" do
         let!(:application_date) { nil }
-        let!(:start_date) { Date.today }
+        let!(:start_date) { Time.zone.today }
 
         it "is a valid person" do
           expect(person).to be_valid
@@ -49,8 +49,8 @@ RSpec.describe Person do
       end
 
       context "when the application date and start date are the same" do
-        let!(:application_date) { Date.today }
-        let!(:start_date) { Date.today }
+        let!(:application_date) { Time.zone.today }
+        let!(:start_date) { Time.zone.today }
 
         it "is a valid person" do
           expect(person).to be_valid
@@ -58,8 +58,8 @@ RSpec.describe Person do
       end
 
       context "when the start date is before the application date" do
-        let!(:application_date) { Date.today }
-        let!(:start_date) { Date.yesterday }
+        let!(:application_date) { Time.zone.today }
+        let!(:start_date) { Time.zone.yesterday }
 
         it "is not a valid person" do
           expect(person).to_not be_valid

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -26,6 +26,46 @@ RSpec.describe Person do
       @person = build(:person, start_date: 2.days.from_now, end_date: 2.days.ago)
       expect(@person).not_to be_valid
     end
+
+    describe "application_date_cannot_be_before_start_date" do
+      let(:person) { build :person, start_date: start_date, application_date: application_date }
+
+      context "when the start date is not present" do
+        let!(:application_date) { Date.today }
+        let!(:start_date) { nil }
+
+        it "is a valid person" do
+          expect(person).to be_valid
+        end
+      end
+
+      context "when the application date is not present" do
+        let!(:application_date) { nil }
+        let!(:start_date) { Date.today }
+
+        it "is a valid person" do
+          expect(person).to be_valid
+        end
+      end
+
+      context "when the application date and start date are the same" do
+        let!(:application_date) { Date.today }
+        let!(:start_date) { Date.today }
+
+        it "is a valid person" do
+          expect(person).to be_valid
+        end
+      end
+
+      context "when the start date is before the application date" do
+        let!(:application_date) { Date.today }
+        let!(:start_date) { Date.yesterday }
+
+        it "is not a valid person" do
+          expect(person).to_not be_valid
+        end
+      end
+    end
   end
 
   describe 'date_last for availability' do


### PR DESCRIPTION
Addresses issue #313

I did not add many feature specs because the validation was thoroughly tested at the model level, but I can certainly add more.