### PR TITLE
When a valid client can not be initialized, throw an error on delivery

### DIFF
--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -34,7 +34,12 @@ class NotificationsController < ApplicationController
     @notification = Notification.new(notification_params)
     if @notification.save
       if @notification.status == "Active"
-        @notification.activate!
+        begin
+          @notification.activate!
+        rescue Message::SendNotificationTextMessage::InvalidClient
+          flash[:error] = 'Notification failed to deliver, no valid delivery client.'
+          return render :new
+        end
       end
       redirect_to @notification.event, notice: 'Notification was successfully created.'
     else

--- a/app/services/message/send_notification_text_message.rb
+++ b/app/services/message/send_notification_text_message.rb
@@ -1,4 +1,5 @@
 class Message::SendNotificationTextMessage
+  class InvalidClient < StandardError; end
   require 'twilio-ruby'
   def initialize
     # create Twilio Client
@@ -15,13 +16,15 @@ class Message::SendNotificationTextMessage
   def sms_send(message, recipient_number,
            sender_number = Setting.get("outbound_text_number"))
     begin
-        message = @client.account.messages.create(:body => message,
-            :to => recipient_number,
-            :from => sender_number)
-        Rails.logger.warn "Sent text message: #{message.inspect}"
-        return message
+      raise InvalidClient.new('Invalid Twilio Client') if @client.nil?
+      message = @client.account.messages.create(
+                    :body => message,
+                    :to => recipient_number,
+                    :from => sender_number)
+      Rails.logger.warn "Sent text message: #{message.inspect}"
+      return message
     rescue Twilio::REST::RequestError => e
-        return e.message
+      return e.message
     end
   end
 end

--- a/spec/controllers/notifications_controller_spec.rb
+++ b/spec/controllers/notifications_controller_spec.rb
@@ -30,6 +30,37 @@ RSpec.describe NotificationsController, type: :controller do
     end
   end
 
+  describe 'POST #create' do
+    let(:notification_params) { { notification: {} } }
+    let(:notification) do
+      FactoryGirl.build(:notification,
+                        status: 'Active',
+                        event: FactoryGirl.create(:event),
+                        departments: [FactoryGirl.build(:department)])
+    end
+
+    before do
+      allow(Notification).to receive(:new) { notification }
+    end
+
+    context 'successfully initialized client' do
+      it 'delivers the notification' do
+        expect(notification).to receive(:activate!)
+        post :create, { notification: { subject: anything } }
+        expect(subject).to redirect_to(notification.event)
+      end
+    end
+
+    context 'unsuccessfully initialized client' do
+      it 'rescues an error and sets a flash message' do
+        expect(notification).to receive(:activate!)
+                            .and_raise(Message::SendNotificationTextMessage::InvalidClient)
+        post :create, { notification: { subject: anything } }
+        expect(subject).to render_template(:new)
+      end
+    end
+  end
+
   describe "UPDATE" do
     # it "re-renders the 'edit' template"
   end


### PR DESCRIPTION
An error is thrown and caught via the NotificationsController to be more
friendly than a "NoMethodError"

Specs were added to the notifications#create method as well.

Addresses #506 