### PR TITLE
#515 - Show short title instead of full title in tables on event availability page

### DIFF
--- a/app/views/availabilities/_availabilities_table.html.erb
+++ b/app/views/availabilities/_availabilities_table.html.erb
@@ -16,7 +16,7 @@
       <!-- Full available -->
     <% (availabilities + partial_availabilities).each do |a| %>
       <tr <%== availability_status_class(a, @event) %>>
-        <td><%= Person::TITLE_ORDER[a.person.shortrank] %></td>
+        <td><%= Person::TITLE_ORDER[a.person.title] %></td>
         <td><%= link_to availability_status_label(a, @event), a %></td>
         <td><%= a.person.shortrank %></td>
         <td><%= link_to a.person.fullname, a.person %></td>

--- a/app/views/availabilities/_availabilities_table.html.erb
+++ b/app/views/availabilities/_availabilities_table.html.erb
@@ -16,9 +16,9 @@
       <!-- Full available -->
     <% (availabilities + partial_availabilities).each do |a| %>
       <tr <%== availability_status_class(a, @event) %>>
-        <td><%= Person::TITLE_ORDER[a.person.title] %></td>
+        <td><%= Person::TITLE_ORDER[a.person.shortrank] %></td>
         <td><%= link_to availability_status_label(a, @event), a %></td>
-        <td><%= a.person.title %></td>
+        <td><%= a.person.shortrank %></td>
         <td><%= link_to a.person.fullname, a.person %></td>
         <td><%= number_to_phone(a.person.phone) %></td>
         <td><%= "#{a.person.dept_shortname} #{a.person.division1}" %></td>

--- a/app/views/people/_people_table.html.erb
+++ b/app/views/people/_people_table.html.erb
@@ -2,7 +2,7 @@
   <caption><h3><%= title %></h3></caption>
   <thead>
     <tr>
-      <th>ID</th>
+      <th>Title</th>
       <th>Name</th>
       <th>Phone</th>
       <th>Dept</th>
@@ -11,7 +11,7 @@
   <tbody>
     <% people.each do |person| %>
       <tr <%== row_class if local_assigns[:row_class] %>>
-        <td><%= person.icsid %></td>
+        <td><%= person.shortrank %></td>
         <td><%= link_to person.fullname, person_path(person) %></td>
         <td><%= number_to_phone(person.phone) %></td>
         <td><%= "#{person.dept_shortname} #{person.division1}" %></td>


### PR DESCRIPTION
In reference to issue #515, changed instances of ID and Title in Availability and No Response tables to show person.shortrank instead.