### PR TITLE
Edit availability includes original person

### DIFF
--- a/app/controllers/availabilities_controller.rb
+++ b/app/controllers/availabilities_controller.rb
@@ -12,15 +12,25 @@ class AvailabilitiesController < ApplicationController
   end
 
   def new
-    @person = Person.find(params[:person_id]) if params.include? "person_id"
-    @event = Event.find(params[:event_id]) if params.include? "event_id"
-    @event = Event.new if @event.blank?
-    @availability = Availability.new(start_time: @event.start_time,
-                                     end_time: @event.end_time)
-    @availability.person = @person if @person
+    person = Person.find(params[:person_id]) if params.include? "person_id"
+    event = Event.find(params[:event_id]) if params.include? "event_id"
+    event = Event.new if event.blank?
+
+    @availability = Availability.new(start_time: event.start_time,
+                                     end_time: event.end_time)
+    @availability.person = person if person
+
+    @people_collection = Person.active
   end
 
   def edit
+    @people_collection = Person.active
+    
+    # Ensure person is included in @people_collection
+    if params.include? 'person_id'
+      person = Person.find params[:person_id]
+      @people_collection |= [person]
+    end
   end
 
   def create

--- a/app/controllers/availabilities_controller.rb
+++ b/app/controllers/availabilities_controller.rb
@@ -21,16 +21,14 @@ class AvailabilitiesController < ApplicationController
     @availability.person = person if person
 
     @people_collection = Person.active
+    @people_collection |= [person]
   end
 
   def edit
     @people_collection = Person.active
     
     # Ensure person is included in @people_collection
-    if params.include? 'person_id'
-      person = Person.find params[:person_id]
-      @people_collection |= [person]
-    end
+    @people_collection |= [@availability.person] if @availability.person
   end
 
   def create

--- a/app/views/availabilities/_form.html.erb
+++ b/app/views/availabilities/_form.html.erb
@@ -2,7 +2,7 @@
   <%= f.error_notification %>
 
   <div class="form-inputs">
-    <%= f.association :person, collection: Person.active %>
+    <%= f.association :person, collection: @people_collection %>
     <%= f.input :status, :as => :select, :collection => Availability::STATUS_CHOICES %>
     <%= f.input :description %>
 

--- a/spec/controllers/availabilities_controller_spec.rb
+++ b/spec/controllers/availabilities_controller_spec.rb
@@ -1,0 +1,68 @@
+require 'rails_helper'
+
+RSpec.describe AvailabilitiesController, type: :controller do
+  
+  before(:each) { login_admin }
+
+  describe 'GET new' do
+    it 'assigns @availability' do
+      get :new
+      expect(assigns(:availability)).not_to be_nil
+    end
+
+    it 'assigns @people_collection' do
+      get :new
+      expect(assigns(:people_collection)).not_to be_nil
+    end
+
+    context 'for an existing event' do
+      let(:event) { create(:event) }
+
+      it 'sets up @availability with the start and end dates of the event' do
+        get :new, { event_id: event.id }
+        expect(assigns(:availability).start_time).to be_within(1.second).of(event.start_time)
+        expect(assigns(:availability).end_time).to be_within(1.second).of(event.end_time)
+      end
+    end
+
+    context 'for an existing person' do
+      let(:person) { create(:person) }
+
+      it 'sets up @availability with the person' do
+        get :new, { person_id: person.id }
+        expect(assigns(:availability).person).to eq(person)
+      end
+    end
+  end
+
+  describe 'GET edit' do
+    let(:person)       { create(:person) }
+    let(:availability) { create(:availability, person: person) }
+
+    it 'assigns @availability' do
+      get :edit, { person_id: person.id, id: availability.id }
+      expect(assigns(:availability)).not_to be_nil
+    end
+
+    describe '@people_collection' do
+      it 'is assigned' do
+        get :edit, { person_id: person.id, id: availability.id }
+        expect(assigns(:people_collection)).not_to be_nil
+      end
+
+      it 'includes the person that is part of the @availability' do
+        get :edit, { person_id: person.id, id: availability.id }
+        expect(assigns(:people_collection)).to include(availability.person)
+      end
+    end
+
+    context 'on an inactive person' do
+      let(:person) { create(:inactive_person) }
+
+      it 'sets up @people_collection including the person' do
+        get :edit, { person_id: person.id, id: availability.id }
+        expect(assigns(:people_collection)).to include(availability.person)
+      end
+    end
+  end
+end

--- a/spec/controllers/availabilities_controller_spec.rb
+++ b/spec/controllers/availabilities_controller_spec.rb
@@ -46,12 +46,12 @@ RSpec.describe AvailabilitiesController, type: :controller do
 
     describe '@people_collection' do
       it 'is assigned' do
-        get :edit, { person_id: person.id, id: availability.id }
+        get :edit, { id: availability.id }
         expect(assigns(:people_collection)).not_to be_nil
       end
 
       it 'includes the person that is part of the @availability' do
-        get :edit, { person_id: person.id, id: availability.id }
+        get :edit, { id: availability.id }
         expect(assigns(:people_collection)).to include(availability.person)
       end
     end
@@ -60,7 +60,7 @@ RSpec.describe AvailabilitiesController, type: :controller do
       let(:person) { create(:inactive_person) }
 
       it 'sets up @people_collection including the person' do
-        get :edit, { person_id: person.id, id: availability.id }
+        get :edit, { id: availability.id }
         expect(assigns(:people_collection)).to include(availability.person)
       end
     end

--- a/spec/factories/person.rb
+++ b/spec/factories/person.rb
@@ -10,5 +10,12 @@ FactoryGirl.define do
     title 'Captain'
     gender 'Female'
     association :department, factory: :department
+  
+    factory :active_person do
+    end
+
+    factory :inactive_person do
+      status "Inactive"
+    end
   end
 end


### PR DESCRIPTION
Fixes #360 

The @availability.person is now always included in the person collection used to populate the select input on the availabilities/_form partial.
Add specs for the availabilites controller #new and #edit actions.
Include child factories that set up active and inactive people.