### PR TITLE
Remove new item button in accordion

### DIFF
--- a/app/views/people/show.html.erb
+++ b/app/views/people/show.html.erb
@@ -91,7 +91,6 @@
     <ul>
       <%= render(@person.items) || raw("No Items Found !") %>
     </ul>
-    <%= independent_button_link 'New Item', new_person_item_path(@person) if can? :create, Item %>
   </div>
 
   <h3>Availabilities (<%= @person.availabilities.uniq.count %>)</h3>


### PR DESCRIPTION
Reference for this issue https://github.com/ReadyResponder/ReadyResponder/issues/539. I remove the button because I think it is better if it only shows the information about the person or maybe we can add edit item functionality from that accordion.