### PR TITLE
440: Remove 'Return To Listing' button from Person#show

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@ playbook.retry
 test_models.rb
 Procfile
 uploads/
+
+# Ignore rvm gemset
+.ruby-gemset

--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -5,7 +5,6 @@ class PeopleController < ApplicationController
   before_action :load_all_depts, only: [:inactive, :everybody]
 
   before_action :set_referrer_path, only: [:new, :edit]
-  before_action :set_return_path, only: [:show]
 
   def signin
     #This is the sign-in sheet, not anything about authentication
@@ -129,14 +128,6 @@ class PeopleController < ApplicationController
 
   def load_all_depts
     @available_departments = Department.all
-  end
-
-  def set_return_path
-    if request.referer
-      (session[:before_show] = request.referer unless request.referer.include? "edit")
-    else
-      (session[:before_show] = people_path)
-    end
   end
 
   def set_referrer_path

--- a/app/views/people/show.html.erb
+++ b/app/views/people/show.html.erb
@@ -1,5 +1,4 @@
 <% content_for :sidebar do %>
-  <%= sidebar_button_link 'Return to Listing', session[:before_show] %>
   <%= sidebar_button_link 'Edit Person', edit_person_path(@person) if can? :edit, @person %>
   <%= sidebar_button_link 'New Certification', new_person_cert_path(@person) if can? :create, Cert %>
   <%= sidebar_button_link 'New Availability', new_person_availability_path(@person) if can? :create, Availability %>

--- a/spec/features/person_displays_spec.rb
+++ b/spec/features/person_displays_spec.rb
@@ -179,38 +179,4 @@ RSpec.describe "Person" do
       expect(page).to have_content("Basket Weaving")
     end
   end
-
-  describe "'Return to Listing' button" do
-    it "redirects to previous category" do
-      cert = create(:department, name: "CERT", shortname: "CERT")
-      person = create(:person, department: cert)
-      visit people_path
-
-      click_link(person.name)
-
-      click_on('Return to Listing')
-
-      expect(current_path).to eq(people_path)
-    end
-
-    it "redirects properly after edit" do
-      cert = create(:department, name: "CERT", shortname: "CERT")
-      person = create(:person, department: cert)
-      visit people_path
-
-      click_link(person.name)
-
-      click_on('Edit Person')
-
-      fill_in 'First Name', with: "Jane"
-      fill_in 'Last Name', with: "Doe"
-
-      click_on('Update Person')
-
-      click_on('Return to Listing')
-
-      expect(current_path).to eq(people_path)
-      expect(page).to have_content("Jane Doe")
-    end
-  end
 end


### PR DESCRIPTION
Fixes: https://github.com/ReadyResponder/ReadyResponder/issues/440

## Approach:
  Removed 'Return to Listing' button along with controller actions to keep track of what the button should return you to.  Removed tests that were associated with the 'Return to Listing' button.

## Notes:
- Added `.ruby-gemset` to the gitignore file so that devs can use it to auto switch gemsets.