### PR TITLE
#555 - displaying assignees as list instead of comma separated values in tasks/show

### DIFF
--- a/app/views/events/_assignee.html.erb
+++ b/app/views/events/_assignee.html.erb
@@ -1,1 +1,2 @@
+<!-- used commonly by tasks/_tasks_table and requirements/_task_requirements_table -->
 <li><%= assignee.fullname %></li>

--- a/app/views/requirements/_task_requirements_table.html.erb
+++ b/app/views/requirements/_task_requirements_table.html.erb
@@ -4,7 +4,7 @@
       <th>Priority</th>
       <th>Qualification</th>
       <th>Status</th>
-      <th></th>
+      <th>Assignees</th>
       <th>Filled</th>
       <th>Min</th>
       <th>Desired</th>
@@ -20,7 +20,7 @@
         <td <%== sorting_order(requirement.priority) %>><%= requirement_priority_label(requirement) %></td>
         <td><%= link_to requirement, requirement %></td>
         <td <%== sorting_order(requirement.status_value) %>><%= requirement_status_label(requirement) %></td>
-        <td><%= requirement.assignees.map{ |p| p.fullname}.join ", " %></td>
+        <td><ol><%= render partial: "events/assignee", collection: requirement.assignees %></ol></td>        
         <td><%= requirement.number_filled %></td>
         <td><%= requirement.minimum_people %></td>
         <td><%= requirement.desired_people %></td>


### PR DESCRIPTION
Issue - https://github.com/ReadyResponder/ReadyResponder/issues/555

**Changes**
1. Added missing header for Assignees
2. Displayed assignees as numbered list instead of comma separated lump, under tasks/show

**Before**

![screen shot 2017-10-15 at 3 41 39 pm](https://user-images.githubusercontent.com/7279519/31583969-805818e8-b1c2-11e7-82d8-3c8d00c63bc5.png)


**After**

![screen shot 2017-10-15 at 3 40 28 pm](https://user-images.githubusercontent.com/7279519/31583972-86d3d0cc-b1c2-11e7-8ee1-661ed4afc74d.png)
