### PR TITLE
Expired cert should not grant skill

### DIFF
--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -7,7 +7,7 @@ class Person < ActiveRecord::Base
 
   before_save :title_order
 
-  has_many :certs, -> { where("certs.status = 'Active'" ) }
+  has_many :certs, -> { where("certs.status = 'Active'") }
   has_many :recipients
   has_many :notifications, :through => :recipients
   has_many :channels
@@ -18,7 +18,7 @@ class Person < ActiveRecord::Base
   accepts_nested_attributes_for :phones, allow_destroy: true
   accepts_nested_attributes_for :emails, allow_destroy: true
   has_many :courses, through: :certs
-  has_many :skills, through: :courses
+  has_many :skills, -> { where("certs.expiration_date > ?", Date.today) }, through: :courses
   has_and_belongs_to_many :titles
   has_many :timecards
   has_many :events, through: :timecards

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -202,7 +202,7 @@ class Person < ActiveRecord::Base
   end
 
   def valid_skills
-    skills.where("certs.expiration_date > ?", Date.today)
+    skills.where("certs.expiration_date > ?", Time.zone.today)
   end
 
   private

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -18,7 +18,7 @@ class Person < ActiveRecord::Base
   accepts_nested_attributes_for :phones, allow_destroy: true
   accepts_nested_attributes_for :emails, allow_destroy: true
   has_many :courses, through: :certs
-  has_many :skills, -> { where("certs.expiration_date > ?", Date.today) }, through: :courses
+  has_many :skills, through: :courses
   has_and_belongs_to_many :titles
   has_many :timecards
   has_many :events, through: :timecards
@@ -199,6 +199,10 @@ class Person < ActiveRecord::Base
         Date.today.year - self.start_date.year + ( self.start_date.yday < Date.today.yday ? 1 : 0 )
       end
     end
+  end
+
+  def valid_skills
+    skills.where("certs.expiration_date > ?", Date.today)
   end
 
   private

--- a/app/views/people/show.html.erb
+++ b/app/views/people/show.html.erb
@@ -58,11 +58,11 @@
 <% end %>
 
 <div class="accordion">
-  <h3>Skills (<%= @person.skills.uniq.count %>)</h3>
+  <h3>Skills (<%= @person.valid_skills.uniq.count %>)</h3>
   <div>
     <table class="table table-striped table-bordered">
       <tbody>
-        <%= render(@person.skills.uniq) || raw("No skills yet !") %>
+        <%= render(@person.valid_skills.uniq) || raw("No skills yet !") %>
       </tbody>
     </table>
   </div>

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171020225113) do
+ActiveRecord::Schema.define(version: 20171018155509) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
This PR is a workaround for #15 

The idea is to only return skills for certifications which haven't expired.