### PR TITLE
#612 - limit repairer select in inspection form to active people

### DIFF
--- a/app/controllers/availabilities_controller.rb
+++ b/app/controllers/availabilities_controller.rb
@@ -22,8 +22,8 @@ class AvailabilitiesController < ApplicationController
     @availability.person = person if person
 
     people = Person.active
-    people |= [person]
-    @people_collection = people.sort_by {|firstname, middleinitial, lastname| "#{firstname} #{middleinitial} #{lastname}"}.compact
+    people |= [person] if person
+    @people_collection = people.sort
   end
 
   def edit
@@ -70,6 +70,6 @@ class AvailabilitiesController < ApplicationController
       
       # Ensure person is included in @people_collection
       @people_collection |= [@availability.person] if @availability.person
-      @people_collection = @people_collection.sort_by {|firstname, middleinitial, lastname| "#{firstname} #{middleinitial} #{lastname}"}.compact
+      @people_collection = @people_collection.sort
     end
 end

--- a/app/controllers/inspections_controller.rb
+++ b/app/controllers/inspections_controller.rb
@@ -14,9 +14,11 @@ class InspectionsController < ApplicationController
 
   def new
     @inspection = @item.inspections.build
+    set_inspectors
   end
 
-  def edit
+  def edit    
+    set_inspectors
   end
 
   def create
@@ -55,5 +57,11 @@ class InspectionsController < ApplicationController
     params.require(:inspection).permit(
       :inspection_date, :status, :comments, :person_id
     )
+  end
+
+  def set_inspectors
+    @inspectors = Person.active    
+    (@inspectors << @inspection.person) if @inspection.try(:person)
+    @inspectors = @inspectors.sort
   end
 end

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -70,6 +70,10 @@ class Person < ActiveRecord::Base
     (fname + " " + (self.middleinitial || "") + " " + self.lastname).squeeze(" ")
   end
 
+  def <=>(other)
+    self.fullname.downcase <=> other.fullname.downcase
+  end
+
   def shortrank
     ranks = { 'Director' => 'Dir', 'Chief' => "Chief", "Deputy Chief" => "Deputy", "Captain" => "Capt",
             "Lieutenant" => "Lt", "Sargeant" => "Sgt", "Corporal" => "Cpl",

--- a/app/views/assignments/_form.html.erb
+++ b/app/views/assignments/_form.html.erb
@@ -3,7 +3,7 @@
 
   <div class="form-inputs">
     <%= f.association :person,
-                collection: Person.active.where(:department => @requirement.event.departments).sort_by {|firstname, middleinitial, lastname| "#{firstname} #{middleinitial} #{lastname}"}.compact %>
+                collection: Person.active.where(:department => @requirement.event.departments).sort %>
     <%= f.input :start_time, as: :string, label: "Start Time",
                 input_html: { class: "datetimepicker", size: 11,
                               value: format_datetime_value(f.object.start_time) } %>

--- a/app/views/inspections/_form.html.erb
+++ b/app/views/inspections/_form.html.erb
@@ -7,7 +7,7 @@
     } %>
 
     <%= f.input :status, as: :select, collection: Inspection::STATUS_CHOICES, selected: "Incomplete" %>
-    <%= f.input :person_id, as: :select, collection: Person.all, allow_blank: true, label: 'Inspector' %>
+    <%= f.input :person_id, as: :select, collection: @inspectors, allow_blank: true, label: 'Inspector' %>
     <%= f.input :comments %>
   </div>
 

--- a/spec/controllers/inspections_controller_spec.rb
+++ b/spec/controllers/inspections_controller_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
-RSpec.describe InspectionsController, type: :controller do
+RSpec.describe InspectionsController, type: :controller do  
+  let(:active_person) { create(:person, firstname: 'Aaon' ) }
+  let(:inactive_person) { create(:inactive_person, firstname: 'Aaby' ) }
   let(:item) { create(:item) }
   let!(:inspections) { create_list(:inspection, 3, item_id: item.id) }
   let(:inspection) { inspections.first }
@@ -25,13 +27,17 @@ RSpec.describe InspectionsController, type: :controller do
     end
   end
 
-  describe '#new' do
+  describe '#new' do    
     subject { get :new, item_id: item.id }
 
-    before { subject }
+    before { 
+      active_person
+      inactive_person
+      subject }
 
-    it 'sets the item' do
+    it 'sets the item and inspectors' do      
       expect(assigns[:item]).to eq(item)
+      expect(assigns[:inspectors]).to eq([active_person, item.owner]), "Should assign only active persons as inspectors"
     end
 
     it 'builds a new inspection for an item & renders' do
@@ -42,9 +48,12 @@ RSpec.describe InspectionsController, type: :controller do
 
   describe '#edit' do
     it 'assigns an inspection & renders' do
-      get :show, id: inspection.id
+      active_person
+      inspection.update_attribute(:person_id, inactive_person.id)
+      get :edit, id: inspection.id
 
       expect(assigns[:inspection]).to eq(inspection)
+      expect(assigns[:inspectors]).to eq([inactive_person, active_person, item.owner])
       expect(response).to be_success
     end
   end

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -189,4 +189,17 @@ RSpec.describe Person do
   describe 'associations' do
     it { is_expected.to have_many(:comments) }
   end
+
+  describe 'sort' do
+    it 'sorts based on first_name, last_name and middleinitial accordingly' do
+      person1 = create(:person, firstname: 'Baily', lastname: 'joss') #6   
+      person2 = create(:person, firstname: 'AAA', lastname: 'Amose') #1
+      person3 = create(:person, firstname: 'Alex', lastname: 'Bane', middleinitial: 'Andy') #4
+      person4 = create(:person, firstname: 'Alex', lastname: 'Bane', middleinitial: 'Bndy') #5
+      person5 = create(:person, firstname: 'Agon', lastname: 'Jane', middleinitial: 'Sndy') #3
+      person6 = create(:person, firstname: 'aaon', lastname: 'Amose', middleinitial: 'Mndy') #2
+      
+      expect(Person.all.sort).to eq([person2, person6, person5, person3, person4, person1])
+    end
+  end
 end


### PR DESCRIPTION
issue: https://github.com/ReadyResponder/ReadyResponder/issues/612

Description: Currently repairer select in inspection form shows all the persons including inactive people, it needs to show only active people.

Changes:
1. Added default sort logic, which sorts based on firstname, lastname and middleinitial to the person model.
2. Updated all places which uses old sorting logic for person to use new logic.
3. Updated repairer select in inspection form to show only active people.
