### PR TITLE
Staffing level endpoint

### DIFF
--- a/app/controllers/api/alert_controller.rb
+++ b/app/controllers/api/alert_controller.rb
@@ -1,7 +1,7 @@
 class Api::AlertController < ApplicationController
 
   def staffing_level
-    @staffing_level = Event.staffing_level
+    @staffing_level = StaffingLevel.staffing_level
     render :show
   end
 end

--- a/app/controllers/api/alert_controller.rb
+++ b/app/controllers/api/alert_controller.rb
@@ -1,0 +1,7 @@
+class Api::AlertController < ApplicationController
+
+  def staffing_level
+    @staffing_level = Event.staffing_level
+    render :show
+  end
+end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -163,13 +163,13 @@ class Event < ApplicationRecord
     end
   end
 
-  # def next_event
-  #   Event.where('start_time > ?', self.start_time).order(:start_time).first
-  # end
+  def next_event
+    Event.where('start_time > ?', self.start_time).order(:start_time).first
+  end
 
-  # def previous_event
-  #   Event.where('start_time < ?', self.start_time).order(start_time: :desc).first
-  # end
+  def previous_event
+    Event.where('start_time < ?', self.start_time).order(start_time: :desc).first
+  end
 
   def staffing_level
     {
@@ -193,9 +193,9 @@ class Event < ApplicationRecord
   end
 
   def calc_duration #This is also used in timecards; it should be extracted out
-     if !(start_time.blank?) and !(end_time.blank?)
+    if !(start_time.blank?) and !(end_time.blank?)
       self.duration = ((end_time - start_time) / 1.hour).round(2) || 0
-     end
+    end
   end
 
   def trim_id_code

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -48,6 +48,14 @@ class Event < ApplicationRecord
 
   CATEGORY_CHOICES = ['Training', 'Patrol', 'Meeting', 'Admin', 'Event']
   STATUS_CHOICES = ['Scheduled', 'In-session', 'Completed', 'Cancelled', "Closed"]
+  STAFFING_LEVELS = {
+    500 => 'Error',
+    0 => 'Empty',
+    1 => 'Inadequate',
+    2 => 'Adequate',
+    3 => 'Satisfied',
+    4 => 'Full'
+  }
 
   def to_s
     title
@@ -161,6 +169,59 @@ class Event < ApplicationRecord
 
   def previous_event
     Event.where('start_time < ?', self.start_time).order(start_time: :desc).first
+  end
+
+  def self.staffing_level
+    begin
+      relevant_events = self.current_or_next_events
+      event_staffings = relevant_events.map do |event|
+        { staffing_number: event.staffing_level,
+          staffing_percentage: event.staffing_percentage }
+      end
+      event_staffing = event_staffings.min_by { |staffing| staffing[:staffing_number] }
+      self.build_staffing_level(event_staffing[:staffing_number], event_staffing[:staffing_percentage])
+    rescue => e
+      puts e
+      self.build_staffing_level(500, "NaN")
+    end
+  end
+
+  def self.build_staffing_level(staffing_number, staffing_percentage)
+    { staffing_level_number: staffing_number,
+      staffing_level_name: STAFFING_LEVELS[staffing_number],
+      staffing_level_percentage: staffing_percentage }
+  end
+
+  def self.current_or_next_events
+    current_events = self.current_events
+    current_events.empty? ? [self.next_event] : current_events
+  end
+
+  def self.current_events
+    self.where("status in (?)", ["Scheduled", "In-session"])
+        .where("start_time < ?", Time.now)
+        .where("end_time > ?", Time.now)
+  end
+
+  def self.next_event
+    next_event = self.where("status in (?)", ["Scheduled", "In-session"])
+        .where("start_time > ?", Time.now)
+        .order("start_time ASC")
+        .first
+    raise '---Error: There are no events---' unless next_event
+    next_event
+  end
+
+  def staffing_level
+    tasks = self.tasks
+    return 0 if tasks.empty? # TODO: verify an event with no tasks should be considered empty.
+    @staffing_level_number = tasks.map { |task| task.staffing_value }.min
+  end
+
+  # TODO: update this once staffing % meaning is clarified.
+  def staffing_percentage
+    @staffing_level_number ||= self.staffing_level
+    @staffing_level_number * 20 + 20
   end
 
 private

--- a/app/models/staffing_level.rb
+++ b/app/models/staffing_level.rb
@@ -1,52 +1,48 @@
-class StaffingLevel < ApplicationRecord
-  include Loggable
+class StaffingLevel
+  def self.staffing_level
+    new.staffing_level
+  end
 
   def staffing_level
     current_or_next_events
       .map(&:staffing_level)
       .min_by { |staffing| staffing[:staffing_level_number] }
+  rescue => e
+    build_staffing_level_error(e)
   end
 
-  def self.staffing_level
+  private
 
-    current_or_next_events
-      .map(&:staffing_level)
-      .min_by { |staffing| staffing[:staffing_level_number] }
-
-    # new.staffing_level
-
-    rescue => e
-      puts e
-      {
-        staffing_number: 500,
-        staffing_level_name: "Error",
-        staffing_level_percentage: "NaN"
-      }
+  def build_staffing_level_error(e)
+    {
+      staffing_level_number: 500,
+      staffing_level_name: "Error: #{e}",
+      staffing_level_percentage: "NaN"
+    }
   end
 
-
-  def self.current_or_next_events
-    current_events = self.current_events
-    current_events.empty? ? [self.next_event] : current_events
+  def current_or_next_events
+    if !current_events.empty?
+      current_events
+    elsif !next_event.empty?
+      next_event
+    else
+      raise StandardError.new("No events to have a staffing level")
+    end
   end
 
-  def self.current_events
-    Event
-      .where("status in (?)", ["Scheduled", "In-session"])
-      .where("start_time < ?", Time.now)
-      .where("end_time > ?", Time.now)
-  end
-
-  def self.next_event
-    next_event =
+  def current_events
+    @current_events ||=
       Event.where("status in (?)", ["Scheduled", "In-session"])
+        .where("start_time < ?", Time.now)
+        .where("end_time > ?", Time.now)
+  end
+
+  def next_event
+    @next_event ||=
+      [Event.where("status in (?)", ["Scheduled", "In-session"])
         .where("start_time > ?", Time.now)
         .order("start_time ASC")
-        .first
-    if !next_event
-      next_event = Event.new
-    end
-    # raise '---Error: There are no events---' unless next_event
-    next_event
+        .first].compact
   end
 end

--- a/app/models/staffing_level.rb
+++ b/app/models/staffing_level.rb
@@ -1,0 +1,52 @@
+class StaffingLevel < ApplicationRecord
+  include Loggable
+
+  def staffing_level
+    current_or_next_events
+      .map(&:staffing_level)
+      .min_by { |staffing| staffing[:staffing_level_number] }
+  end
+
+  def self.staffing_level
+
+    current_or_next_events
+      .map(&:staffing_level)
+      .min_by { |staffing| staffing[:staffing_level_number] }
+
+    # new.staffing_level
+
+    rescue => e
+      puts e
+      {
+        staffing_number: 500,
+        staffing_level_name: "Error",
+        staffing_level_percentage: "NaN"
+      }
+  end
+
+
+  def self.current_or_next_events
+    current_events = self.current_events
+    current_events.empty? ? [self.next_event] : current_events
+  end
+
+  def self.current_events
+    Event
+      .where("status in (?)", ["Scheduled", "In-session"])
+      .where("start_time < ?", Time.now)
+      .where("end_time > ?", Time.now)
+  end
+
+  def self.next_event
+    next_event =
+      Event.where("status in (?)", ["Scheduled", "In-session"])
+        .where("start_time > ?", Time.now)
+        .order("start_time ASC")
+        .first
+    if !next_event
+      next_event = Event.new
+    end
+    # raise '---Error: There are no events---' unless next_event
+    next_event
+  end
+end

--- a/app/models/staffing_level.rb
+++ b/app/models/staffing_level.rb
@@ -27,7 +27,7 @@ class StaffingLevel
     elsif !next_event.empty?
       next_event
     else
-      raise StandardError.new("No events to have a staffing level")
+      raise StandardError.new("There are no events to have a staffing level for")
     end
   end
 

--- a/app/views/api/alert/show.json.jbuilder
+++ b/app/views/api/alert/show.json.jbuilder
@@ -1,0 +1,3 @@
+json.staffing_level_number @staffing_level[:staffing_level_number]
+json.staffing_level_name @staffing_level[:staffing_level_name]
+json.staffing_level_percentage @staffing_level[:staffing_level_percentage]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -103,6 +103,10 @@ Rails.application.routes.draw do
 
   resources :assignments, except: [:new, :create], constraints: { id: /\d+/ }
 
+  namespace :api, defaults: {format: :json} do
+    get '/staffinglevel', to: 'alert#staffing_level'
+  end
+
   root "landing#index"
 
 end

--- a/spec/features/alert_spec.rb
+++ b/spec/features/alert_spec.rb
@@ -1,0 +1,236 @@
+require 'rails_helper'
+
+# Tasks can be [Empty, Inadequate, Adequate, Satisfied, Full].
+# Each task has min, desired and max staffing.
+# If assignments are zero, then empty.
+# Above zero, but below min, inadequate.
+# Above min, but below desired, adequate.
+# Above desired, satisfied.
+# At max, full.
+#
+# Events have many tasks
+# An event's staffing level is ditacted by the event's worst case task
+# staffing-level.
+#
+# Let's say I have a shelter event, with two tasks. Medical intake and parking.
+# If medical intake were satisfied, but parking was empty, the event should be
+# Empty.
+#
+# Event.staffing_level[:staffing_level_number] returns the worst case
+# staffing-level of all currently happening events.
+# If there are no currently happening events, it returns the staffing level of
+# the next event to occur.
+#
+# The method returns an integer 0-4 as follows:
+#
+# {
+#   'Empty' => 0,
+#   'Inadequate' => 1,
+#   'Adequate' => 2,
+#   'Satisfied' => 3,
+#   'Full' => 4
+# }
+#
+# errors return 500
+
+RSpec.describe Event do
+
+  describe "Event.staffing_level" do
+    let(:department) { create(:department, { shortname: "CERT" })}
+    let(:person1) { create(:person, { department: department }) }
+    let(:person2) { create(:person, { department: department }) }
+    let(:person3) { create(:person, { department: department }) }
+    let(:person4) { create(:person, { department: department }) }
+    let(:person5) { create(:person, { department: department }) }
+    let(:title1) { create(:title, { name: "title 1" })}
+    let(:title2) { create(:title, { name: "title 2" })}
+
+    context "single currently happening event" do
+      before(:each) do
+        @event = create(:event, {
+            start_time: 1.hour.ago,
+            end_time: 1.hour.from_now,
+            departments: [department]
+          })
+        @task1 = create(:task, {
+            event_id: @event.id,
+            status: 'Active',
+            start_time: 1.hour.ago,
+            end_time: 1.hour.from_now
+          })
+        @requirement1 = create(:requirement, {
+            task_id: @task1.id,
+            title: title1,
+            minimum_people: 2,
+            maximum_people: 5,
+            desired_people: 3
+          })
+      end
+
+      it "returns 0 when at least 1 task is Empty" do
+        expect(Event.staffing_level[:staffing_level_number]).to eq(0)
+      end
+
+      it "returns 1 when at least 1 task is Inadequate and no tasks are worse" do
+        create(:assignment, {
+          person: person1,
+          requirement: @requirement1
+        })
+        expect(Event.staffing_level[:staffing_level_number]).to eq(1)
+      end
+
+      it "returns 2 when at least 1 task is Adquate and no tasks are worse" do
+        [person1, person2].each do |person|
+          create(:assignment, {
+            person: person,
+            requirement: @requirement1
+          })
+        end
+        expect(Event.staffing_level[:staffing_level_number]).to eq(2)
+      end
+
+      it "returns 3 when at least 1 task is Satisfied and no tasks are worse" do
+        [person1, person2, person3].each do |person|
+          create(:assignment, {
+            person: person,
+            requirement: @requirement1
+          })
+        end
+        expect(Event.staffing_level[:staffing_level_number]).to eq(3)
+      end
+
+      it "returns 4 when all tasks are Full" do
+        [person1, person2, person3, person4, person5].each do |person|
+          create(:assignment, {
+            person: person,
+            requirement: @requirement1
+          })
+        end
+        expect(Event.staffing_level[:staffing_level_number]).to eq(4)
+      end
+
+      it "uses the worst case task if event has multiple tasks" do
+        @task2 = create(:task, {
+          event_id: @event.id,
+          status: 'Active',
+          start_time: 1.hour.ago,
+          end_time: 1.hour.from_now
+        })
+      @requirement2 = create(:requirement, {
+          task_id: @task2.id,
+          title: title1,
+          minimum_people: 2,
+          maximum_people: 5,
+          desired_people: 3
+        })
+        [person1, person2, person3].each do |person|
+          create(:assignment, {
+            person: person,
+            requirement: @requirement1
+          })
+        end
+        create(:assignment, {
+          person: person4,
+          requirement: @requirement2
+        })
+        expect(Event.staffing_level[:staffing_level_number]).to eq(1)
+      end
+    end
+
+    context "multiple currently happening events" do
+      before(:each) do
+        @event1 = create(:event, {
+            start_time: 1.hour.ago,
+            end_time: 1.hour.from_now,
+            departments: [department]
+          })
+        @task1 = create(:task, {
+            event_id: @event1.id,
+            status: 'Active',
+            start_time: 1.hour.ago,
+            end_time: 1.hour.from_now
+          })
+        @requirement1 = create(:requirement, {
+            task_id: @task1.id,
+            title: title1,
+            minimum_people: 2,
+            maximum_people: 5,
+            desired_people: 3
+          })
+        @event2 = create(:event, {
+            start_time: 1.hour.ago,
+            end_time: 1.hour.from_now,
+            departments: [department]
+          })
+        @task2 = create(:task, {
+            event_id: @event2.id,
+            status: 'Active',
+            start_time: 1.hour.ago,
+            end_time: 1.hour.from_now
+          })
+        @requirement2 = create(:requirement, {
+            task_id: @task2.id,
+            title: title2,
+            minimum_people: 2,
+            maximum_people: 5,
+            desired_people: 3
+          })
+      end
+
+      it "returns the worse case event staffing level" do
+        [person1, person2, person3].each do |person|
+          create(:assignment, {
+            person: person,
+            requirement: @requirement1
+          })
+        end
+
+        [person4].each do |person|
+          create(:assignment, {
+            person: person,
+            requirement: @requirement2
+          })
+        end
+
+        expect(Event.staffing_level[:staffing_level_number]).to eq(1)
+      end
+    end
+
+    context "no currently happening event" do
+      before(:each) do
+        @event = create(:event, {
+            start_time: 10.hours.from_now,
+            end_time: 11.hours.from_now,
+            departments: [department]
+          })
+        @task1 = create(:task, {
+            event_id: @event.id,
+            status: 'Active',
+            start_time: 1.hour.ago,
+            end_time: 1.hour.from_now
+          })
+        @requirement1 = create(:requirement, {
+            task_id: @task1.id,
+            title: title1,
+            minimum_people: 2,
+            maximum_people: 5,
+            desired_people: 3
+          })
+      end
+
+      it "finds the next event to happen and returns the staffing_level" do
+        [person1, person2].each do |person|
+          create(:assignment, {
+            person: person,
+            requirement: @requirement1
+          })
+        end
+        expect(Event.staffing_level[:staffing_level_number]).to eq(2)
+      end
+    end
+
+    it "returns 500 on error" do
+      expect(Event.staffing_level[:staffing_level_number]).to eq(500)
+    end
+  end
+end

--- a/spec/models/staffing_level_spec.rb
+++ b/spec/models/staffing_level_spec.rb
@@ -16,7 +16,7 @@ require 'rails_helper'
 # If medical intake were satisfied, but parking was empty, the event should be
 # Empty.
 #
-# Event.staffing_level[:staffing_level_number] returns the worst case
+# StaffingLevel.staffing_level[:staffing_level_number] returns the worst case
 # staffing-level of all currently happening events.
 # If there are no currently happening events, it returns the staffing level of
 # the next event to occur.
@@ -33,17 +33,16 @@ require 'rails_helper'
 #
 # errors return 500
 
-RSpec.describe Event do
-
-  describe "Event.staffing_level" do
-    let(:department) { create(:department, { shortname: "CERT" })}
-    let(:person1) { create(:person, { department: department }) }
-    let(:person2) { create(:person, { department: department }) }
-    let(:person3) { create(:person, { department: department }) }
-    let(:person4) { create(:person, { department: department }) }
-    let(:person5) { create(:person, { department: department }) }
-    let(:title1) { create(:title, { name: "title 1" })}
-    let(:title2) { create(:title, { name: "title 2" })}
+RSpec.describe StaffingLevel do
+  describe ".staffing_level" do
+    let(:department) { create(:department, shortname: "CERT")}
+    let(:person1) { create(:person, department: department) }
+    let(:person2) { create(:person, department: department) }
+    let(:person3) { create(:person, department: department) }
+    let(:person4) { create(:person, department: department) }
+    let(:person5) { create(:person, department: department) }
+    let(:title1) { create(:title, name: "title 1")}
+    let(:title2) { create(:title, name: "title 2")}
 
     context "single currently happening event" do
       before(:each) do
@@ -68,7 +67,7 @@ RSpec.describe Event do
       end
 
       it "returns 0 when at least 1 task is Empty" do
-        expect(Event.staffing_level[:staffing_level_number]).to eq(0)
+        expect(StaffingLevel.staffing_level[:staffing_level_number]).to eq(0)
       end
 
       it "returns 1 when at least 1 task is Inadequate and no tasks are worse" do
@@ -76,7 +75,7 @@ RSpec.describe Event do
           person: person1,
           requirement: @requirement1
         })
-        expect(Event.staffing_level[:staffing_level_number]).to eq(1)
+        expect(StaffingLevel.staffing_level[:staffing_level_number]).to eq(1)
       end
 
       it "returns 2 when at least 1 task is Adquate and no tasks are worse" do
@@ -86,7 +85,7 @@ RSpec.describe Event do
             requirement: @requirement1
           })
         end
-        expect(Event.staffing_level[:staffing_level_number]).to eq(2)
+        expect(StaffingLevel.staffing_level[:staffing_level_number]).to eq(2)
       end
 
       it "returns 3 when at least 1 task is Satisfied and no tasks are worse" do
@@ -96,7 +95,7 @@ RSpec.describe Event do
             requirement: @requirement1
           })
         end
-        expect(Event.staffing_level[:staffing_level_number]).to eq(3)
+        expect(StaffingLevel.staffing_level[:staffing_level_number]).to eq(3)
       end
 
       it "returns 4 when all tasks are Full" do
@@ -106,7 +105,7 @@ RSpec.describe Event do
             requirement: @requirement1
           })
         end
-        expect(Event.staffing_level[:staffing_level_number]).to eq(4)
+        expect(StaffingLevel.staffing_level[:staffing_level_number]).to eq(4)
       end
 
       it "uses the worst case task if event has multiple tasks" do
@@ -133,7 +132,7 @@ RSpec.describe Event do
           person: person4,
           requirement: @requirement2
         })
-        expect(Event.staffing_level[:staffing_level_number]).to eq(1)
+        expect(StaffingLevel.staffing_level[:staffing_level_number]).to eq(1)
       end
     end
 
@@ -192,7 +191,7 @@ RSpec.describe Event do
           })
         end
 
-        expect(Event.staffing_level[:staffing_level_number]).to eq(1)
+        expect(StaffingLevel.staffing_level[:staffing_level_number]).to eq(1)
       end
     end
 
@@ -225,12 +224,15 @@ RSpec.describe Event do
             requirement: @requirement1
           })
         end
-        expect(Event.staffing_level[:staffing_level_number]).to eq(2)
+        expect(StaffingLevel.staffing_level[:staffing_level_number]).to eq(2)
       end
     end
 
-    it "returns 500 on error" do
-      expect(Event.staffing_level[:staffing_level_number]).to eq(500)
+    context "when there is an internal server error" do
+      it "returns 500" do
+
+        expect(StaffingLevel.staffing_level[:staffing_level_number]).to eq(500)
+      end
     end
   end
 end

--- a/spec/models/staffing_level_spec.rb
+++ b/spec/models/staffing_level_spec.rb
@@ -230,8 +230,15 @@ RSpec.describe StaffingLevel do
 
     context "when there is an internal server error" do
       it "returns 500" do
+        staffing_level = StaffingLevel.new
+        allow(staffing_level).to(
+          receive(:current_or_next_events).and_raise(StandardError.new("error"))
+        )
+        allow(StaffingLevel).to receive(:new).and_return(staffing_level)
 
-        expect(StaffingLevel.staffing_level[:staffing_level_number]).to eq(500)
+        result = StaffingLevel.staffing_level
+
+        expect(result[:staffing_level_number]).to eq(500)
       end
     end
   end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -5,6 +5,7 @@ require File.expand_path('../../config/environment', __FILE__)
 abort("The Rails environment is running in production mode!") if Rails.env.production?
 require 'spec_helper'
 require 'rspec/rails'
+require 'shoulda/matchers'
 
 # Requires supporting ruby files with custom matchers and macros, etc,
 # in spec/support/ and its subdirectories.

--- a/spec/requests/staffing_level_spec.rb
+++ b/spec/requests/staffing_level_spec.rb
@@ -2,11 +2,11 @@ require 'rails_helper'
 
 RSpec.describe "GET /api/staffinglevel", type: :request do
   context "When there are no events" do
-    it "returns the empty staffing level" do
+    it "returns the error staffing level" do
       expected_json = {
-        "staffing_level_name" => "Empty",
-        "staffing_level_number" => 0,
-        "staffing_level_percentage" => 20
+        "staffing_level_name" => "Error",
+        "staffing_level_number" => 500,
+        "staffing_level_percentage" => "NaN"
       }
 
       get "/api/staffinglevel"

--- a/spec/requests/staffing_level_spec.rb
+++ b/spec/requests/staffing_level_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe "GET /api/staffinglevel", type: :request do
   context "When there are no events" do
     it "returns the error staffing level" do
       expected_json = {
-        "staffing_level_name" => "Error",
+        "staffing_level_name" => "Error: There are no events to have a staffing level for",
         "staffing_level_number" => 500,
         "staffing_level_percentage" => "NaN"
       }

--- a/spec/requests/staffing_level_spec.rb
+++ b/spec/requests/staffing_level_spec.rb
@@ -1,0 +1,59 @@
+require 'rails_helper'
+
+RSpec.describe "GET /api/staffinglevel", type: :request do
+  context "When there are no events" do
+    it "returns the empty staffing level" do
+      expected_json = {
+        "staffing_level_name" => "Empty",
+        "staffing_level_number" => 0,
+        "staffing_level_percentage" => 20
+      }
+
+      get "/api/staffinglevel"
+
+      expect(json_body).to eq(expected_json)
+    end
+  end
+
+  context "When there are events" do
+    it "returns the staffing level for the next event" do
+      department = create(:department)
+      event = create(
+        :event,
+        start_time: 1.hour.ago,
+        end_time: 1.hour.from_now
+      )
+      task = create(
+        :task,
+        event: event,
+        start_time: 1.hour.ago,
+        end_time: 1.hour.from_now
+      )
+      title = create(:title)
+      requirement = create(
+        :requirement,
+        task: task,
+        title: title,
+        minimum_people: 1,
+        maximum_people: 2,
+        desired_people: 1
+      )
+      person = create(:person, department: department)
+      create(:assignment, person: person, requirement: requirement)
+
+      expected_json = {
+        "staffing_level_name" => "Satisfied",
+        "staffing_level_number" => 3,
+        "staffing_level_percentage" => 80
+      }
+
+      get "/api/staffinglevel"
+
+      expect(json_body).to eq(expected_json)
+    end
+  end
+end
+
+def json_body
+  JSON.parse(response.body)
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,6 +1,7 @@
 ENV['RAILS_ENV'] ||= 'test'
 require File.expand_path('../../config/environment', __FILE__)
 require 'rails/test_help'
+include Shoulda::Matchers::Routing
 
 class ActiveSupport::TestCase
   ActiveRecord::Migration.check_pending!


### PR DESCRIPTION
This creates an endpoint that responds with the current Event staffing level that will be used for the alert indicator device.

It is scoped under an api namespace to keep it seperate from the main application.

making a get request to ```/api/staffinglevel``` should return some json of the form: 
```
{staffing_level_number: 3, staffing_level_name: "Satisfied", staffing_level_percentage: 80}
```

jbuilder was added to the gemfile to help with the structuring of the json data.

Testing for the Event model was added in ```spec/features/alert_spec.rb```

Note that there is currently no authentication happening at the controller level.  I think this is okay for now since the endpoint doesn't allow for any mutations.  Authentication can be added later after the IoT end of this is more fully worked out.