### PR TITLE
Added 'last inspection' to item_type index

### DIFF
--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -37,7 +37,7 @@ class Item < ActiveRecord::Base
            reject_if: :all_blank
 
   STATUS_CHOICES = ['Assigned', 'Unassigned', 'Retired']
-  CONDITION_CHOICES = ['Ready', 'In-Service - Maintenance', 
+  CONDITION_CHOICES = ['Ready', 'In-Service - Maintenance',
                        'In-Service - Degraded', 'Out of Service']
 
   def to_s
@@ -51,6 +51,10 @@ class Item < ActiveRecord::Base
   def location_name
     return location.name if location
     "Unknown"
+  end
+
+  def last_inspection_date
+    inspections.order('inspection_date DESC').first.inspection_date
   end
 
   def set_repair_condition

--- a/app/views/items/_items_table.html.erb
+++ b/app/views/items/_items_table.html.erb
@@ -7,6 +7,7 @@
       <th>Status</th>
       <th>Condition</th>
       <th>Location</th>
+      <th>Last Inspection</th>
       <th></th>
     </tr>
   </thead>
@@ -19,6 +20,7 @@
         <td><%= item_status_label(item) %></td>
         <td><%= item_condition_label(item) %></td>
         <td><%= item.location.name if item.location %></td>
+        <td><%= item.last_inspection_date %></td>
         <td><%= table_button_link 'Edit', edit_item_path(item) unless cannot? :edit, item %></td>
       </tr>
     <% end %>

--- a/spec/features/inspection_display_spec.rb
+++ b/spec/features/inspection_display_spec.rb
@@ -37,6 +37,17 @@ RSpec.describe "Inspection" do
     end
   end
 
+  context "on item index" do
+    let(:an_item) { create(:item, item_type_id: 1) }
+    let!(:an_inspection) { create(:inspection, item: an_item, inspection_date: 1.day.ago) }
+    let!(:an_older_inspection) { create(:inspection, item: an_item, inspection_date: 2.days.ago) }
+    it "should show last inspection date" do
+      visit item_type_path(an_item.item_type_id)
+      expect(page).to have_content(an_inspection.inspection_date)
+      expect(page).not_to have_content(an_older_inspection.inspection_date)
+    end
+  end
+
   context "from an item" do
     let!(:item)  { create(:item) }
     it "should create an inspection for that item" do


### PR DESCRIPTION
Issue: https://github.com/ReadyResponder/ReadyResponder/issues/613
Adds the last inspection date of a given item to the item_type show page, where individual items are displayed. 

Last_inspection_date query added to model.

Testing added in `features/inspection_display_spec.rb`
  