### PR TITLE
Restored missing scope on availability

### DIFF
--- a/app/models/availability.rb
+++ b/app/models/availability.rb
@@ -11,6 +11,10 @@ class Availability < ActiveRecord::Base
 
   STATUS_CHOICES = [ 'Available', 'Unavailable', "Cancelled" ]
 
+  # Available the entire event
+  scope :for_time_span, ->(range) { where("end_time >= ?", range.last).
+                               where("start_time <= ?", range.first) }
+
   # Available part of event
   scope :partially_available, ->(range) { where("? > end_time AND end_time > ? OR ? > start_time AND start_time > ?", range.last, range.first, range.last, range.first) }
 
@@ -24,11 +28,11 @@ class Availability < ActiveRecord::Base
   # on its range data type implementation. The ranges are left_bound closed
   # and right_bound open, as specified by the argument '[)'
   # reference: https://www.postgresql.org/docs/9.5/static/rangetypes.html
-  scope :overlapping, lambda { |range|  
+  scope :overlapping, lambda { |range|
     where("tsrange(start_time, end_time, '[)') && tsrange(TIMESTAMP?, TIMESTAMP?, '[)')",
           range.first, range.last) }
 
-  scope :not_overlapping, lambda { |range|  
+  scope :not_overlapping, lambda { |range|
     where.not("tsrange(start_time, end_time, '[)') && tsrange(TIMESTAMP?, TIMESTAMP?, '[)')",
           range.first, range.last) }
 


### PR DESCRIPTION
This had been accidentally removed in an early commit
Fixes #658 