### PR TITLE
Don't specify insecure 'git:' gem src in Gemfile.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -74,7 +74,7 @@ group :development do
 
   # Helps you figure out where a piece of the UI is coming from by
   # adding comments to the source code at the begin and end of each template.
-  gem 'noisy_partials', git: 'git://github.com/gwshaw/noisy_partials.git'
+  gem 'noisy_partials', git: 'https://github.com/gwshaw/noisy_partials.git'
 end
 
 group :production do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,5 +1,5 @@
 GIT
-  remote: git://github.com/gwshaw/noisy_partials.git
+  remote: https://github.com/gwshaw/noisy_partials.git
   revision: 9e7110bb400cd7d366adc706d7ce0934cfd3c0eb
   specs:
     noisy_partials (0.0.0)


### PR DESCRIPTION
Fixes security issue that `bundle install` is warning about.