### PR TITLE
Js add specs for availablities on event show page

### DIFF
--- a/spec/factories/availabilities.rb
+++ b/spec/factories/availabilities.rb
@@ -4,5 +4,6 @@ FactoryGirl.define do
     end_time 15.hours.from_now
     status "Unavailable"
     description "Vacation"
+    person
   end
 end

--- a/spec/features/events/user_visits_event_page_spec.rb
+++ b/spec/features/events/user_visits_event_page_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+RSpec.feature "User visits and event show page", type: :feature do
+  scenario "It shows the availablitites", js: true do
+    sign_in_as('Editor')
+
+    event_start_time = 2.hours.from_now
+    event_end_time = 12.hours.from_now
+    event = create(:event, start_time: event_start_time, end_time: event_end_time)
+
+    time_before_event = 1.hour.from_now
+    time_after_event = 13.hours.from_now
+    first_full_availability = create(:availability, start_time: time_before_event, end_time: time_after_event)
+    second_full_availability = create(:availability, start_time: time_before_event, end_time: time_after_event)
+    
+    visit events_path
+    click_on event.title
+    click_on "Availabilities"
+
+    expect(page).to have_content "Available", count: 2
+    expect(page).to have_content first_full_availability.person.name, count: 1
+    expect(page).to have_content second_full_availability.person.name, count: 1
+  end
+end

--- a/spec/requests/events_spec.rb
+++ b/spec/requests/events_spec.rb
@@ -1,0 +1,81 @@
+require 'rails_helper'
+require 'support/request_helper'
+
+RSpec.describe "GET events/:id", type: :request do
+  describe "Availablities table shows correct availablities" do
+    before(:each) do
+      login_as_editor
+
+      @event_start_time = 2.hours.from_now
+      @event_end_time = 12.hours.from_now
+      @event = create(:event, start_time: @event_start_time, end_time: @event_end_time)
+
+      @two_hours_before_event_start = @event_start_time - 2.hours
+      @two_hours_after_event_start = @event_start_time + 2.hours
+      @two_hours_before_event_end = @event_end_time - 2.hours
+      @two_hours_after_event_end = @event_end_time + 2.hours
+    end
+
+    context "when the availablites are partially available" do
+      it "returns availabilities that start before the event and end during the event" do
+        availability = create(:availability, start_time: @two_hours_before_event_start, end_time: @two_hours_after_event_start)
+
+        get "/events/#{@event.id}"
+
+        expect(response.body).to include(availability.person.name)
+      end
+
+      it "returns availablities that start during the event and end during the event" do
+        availability = create(:availability, start_time: @two_hours_after_event_start, end_time: @two_hours_before_event_end)
+
+        get "/events/#{@event.id}"
+
+        expect(response.body).to include(availability.person.name)
+      end
+
+      it "returns availablities that start during the event and end after the event" do
+        availability = create(:availability, start_time: @two_hours_after_event_start, end_time: @two_hours_after_event_end)
+
+        get "/events/#{@event.id}"
+
+        expect(response.body).to include(availability.person.name)
+      end
+    end
+
+    context "when the availablities are fully available" do
+      it "returns availablites that start before the event and end after the event" do
+        availability = create(:availability, start_time: @two_hours_before_event_start, end_time: @two_hours_after_event_end)
+
+        get "/events/#{@event.id}"
+
+        expect(response.body).to include(availability.person.name)
+      end
+
+      it "returns availablities that start and end at the same times as the event" do
+        availability = create(:availability, start_time: @event_start_time, end_time: @event_end_time)
+
+        get "/events/#{@event.id}"
+
+        expect(response.body).to include(availability.person.name)
+      end
+    end
+
+    context "when the availablities are not available" do
+      it "does not return availablities that end before the event" do
+        availability = create(:availability, start_time: @two_hours_before_event_start - 1.hour, end_time: @two_hours_before_event_start)
+
+        get "/events/#{@event.id}"
+
+        expect(response.body).to_not include(availability.person.name)
+      end
+
+      it "does not return availablities that start after the event" do
+        availability = create(:availability, start_time: @two_hours_after_event_end, end_time: @two_hours_after_event_end + 1.hour)
+
+        get "/events/#{@event.id}"
+
+        expect(response.body).to_not include(availability.person.name)
+      end
+    end
+  end
+end

--- a/spec/support/request_helper.rb
+++ b/spec/support/request_helper.rb
@@ -1,0 +1,9 @@
+def login_as_editor
+  user = create(:user, roles: [create(:role, name: 'Editor')])
+  login(user)
+end
+
+# use this for request specs
+def login(user)
+  post_via_redirect user_session_path, 'user[email]' => user.email, 'user[password]' => user.password
+end


### PR DESCRIPTION
[issue 679](https://github.com/ReadyResponder/ReadyResponder/issues/679)

This adds a feature spec and request specs for viewing the correct availabilities in the Availabilities table on events#show.

The feature spec runs on my machine in about 12 seconds
The request specs run on my machine in about 9 seconds

given there are about 8 cases that were wanted to be tested, I didn't want to use feature specs for all of them because that would have added about 96seconds to the test suite.

currently the feature spec is failing. and the request specs that test partial availability are also failing.

I don't have a lot of confidence in these tests since the app is currently not showing availabilities correctly, I'm not sure what the intended behavior is exactly or if the tests will pass properly once the main feature is fixed. 

I would suggest not merging this in yet until the tests have had some verification that the are testing the intended behavior.  I am creating this PR to start that discussion.