### PR TITLE
687 - new item type page error

### DIFF
--- a/app/controllers/item_types_controller.rb
+++ b/app/controllers/item_types_controller.rb
@@ -12,7 +12,7 @@ class ItemTypesController < ApplicationController
 
   def new
     @item_type = ItemType.new
-    @item_type.item_category = ItemCategory.find(params[:item_category_id])
+    @item_type.item_category = ItemCategory.find(params[:item_category_id]) if params[:item_category_id]
     @item_type.status = "Active"
   end
 
@@ -38,6 +38,7 @@ class ItemTypesController < ApplicationController
 
   def destroy
     @item_type.destroy
+    redirect_to item_types_url
   end
 
   private

--- a/spec/controllers/item_types_controller_spec.rb
+++ b/spec/controllers/item_types_controller_spec.rb
@@ -1,0 +1,160 @@
+require 'rails_helper'
+
+RSpec.describe ItemTypesController, type: :controller do
+  let!(:item_category) { create(:item_category) }
+  let!(:item_type) { create(:item_type, item_category: item_category, name: 'item1') }
+  let!(:item_type2) { create(:item_type, item_category: item_category) }
+
+  before { login_manager }
+
+  describe '#index' do
+    it 'assigns item_types & renders' do
+      get :index
+
+      expect(assigns[:item_types].sort).to eq([item_type, item_type2].sort)
+      expect(response).to be_success
+    end
+  end
+
+  describe '#show' do
+    it 'assigns an item_type & renders' do
+      get :show, id: item_type.id
+
+      expect(assigns[:item_type]).to eq(item_type)
+      expect(response).to be_success
+    end
+  end
+
+  describe '#new' do
+    context 'without item_category' do
+      it 'builds a new item_type & renders' do
+        get :new
+
+        expect(assigns[:item_type]).to have_attributes(status: 'Active')
+        expect(response).to be_success
+      end
+    end
+
+    context 'with item_category' do
+      it 'builds a new item_type & renders' do
+        get :new, item_category_id: item_category.id
+
+        expect(assigns[:item_type]).to have_attributes(status: 'Active')
+        expect(assigns[:item_type]).to have_attributes(item_category_id: item_category.id)
+        expect(response).to be_success
+      end
+    end
+
+  end
+
+  describe '#edit' do
+    it 'assigns an item_type & renders' do
+      get :edit, id: item_type.id
+
+      expect(assigns[:item_type]).to eq(item_type)
+      expect(response).to be_success
+    end
+  end
+
+  describe '#create' do
+    let!(:item_category) {create(:item_category)}
+    let!(:item_type_params) do
+      {
+        item_type:{
+          name: 'Item type name',
+          item_category_id: item_category.id,
+          status: 'Inactive'
+        }
+      }
+    end
+
+    subject { post :create, item_type_params }
+
+    context 'with a successful save' do
+      it 'creates a new item_type' do
+        expect { subject }.to change { ItemType.count }.by(1)
+      end
+
+      it 'flashes a notice & redirects' do
+        subject
+
+        expect(flash[:notice]).to eq('Item type was successfully created.')
+        expect(response).to redirect_to(item_type_path(assigns[:item_type]))
+      end
+    end
+
+    context 'with errors' do
+      let!(:invalid_item_type_params) do
+        {
+          item_type: {item_category_id: nil}
+        }
+      end
+
+      subject { post :create, invalid_item_type_params }
+
+      it "doesn't create a new item_type" do
+        expect { subject }.to_not change { ItemType.count }
+      end
+
+      it 'renders' do
+        subject
+
+        expect(response).to render_template(:new)
+      end
+    end
+  end
+
+  describe '#update' do
+    let(:item_type_params) do
+      {
+        id: item_type.id,
+        item_type: { name: 'New name'}
+      }
+    end
+
+    subject { put :update, item_type_params }
+
+    context 'with a successful update' do
+      it 'updates the item_type' do
+        expect { subject }.to change { item_type.reload.name }.from('item1').to('New name')
+      end
+
+      it 'flashes a notice & redirects' do
+        subject
+
+        expect(flash[:notice]).to eq('Item type was successfully updated.')
+        expect(response).to redirect_to(item_type_path(item_type))
+      end
+    end
+
+    context 'with errors' do
+      let(:invalid_item_type_params) do
+        item_type_params.tap do |params|
+          params[:item_type][:item_category_id] = nil
+          params[:item_type][:name] = 'New name'
+        end
+      end
+
+      subject { put :update, invalid_item_type_params }
+
+      it "doesn't create a new item_type" do
+        expect { subject }.to_not change { item_type.name }
+      end
+
+      it 'renders' do
+        subject
+
+        expect(response).to render_template(:edit)
+      end
+    end
+  end
+
+  describe '#destroy' do
+    it 'deletes an item_type' do
+      delete :destroy, id: item_type.id
+
+      expect { item_type.reload }.to raise_error(ActiveRecord::RecordNotFound)
+      expect(response).to redirect_to(item_types_url)
+    end
+  end
+end


### PR DESCRIPTION
Issue: https://github.com/ReadyResponder/ReadyResponder/issues/687

## Change summary
Reason:
For item type there are two routes
1. One with item_category new, from item_categories, http://localhost:3000/item_categories/1/item_types/new
2. Without item_category, from item_types/new

2 Was causing errors, as action `new` always searches for item_category.

Fix: 
Fixed it by searching for item_category only if item_category params are present.

Also added missing tests for item_types_controller, and added redirect for delete action.