### PR TITLE
Certs <-- has and belongs to many --> Courses

### DIFF
--- a/app/models/cert.rb
+++ b/app/models/cert.rb
@@ -2,13 +2,14 @@ class Cert < ActiveRecord::Base
   has_paper_trail
   include Loggable
 
-  attr_accessible :category, :person_id, :course_id, :expiration_date, :issued_date, :cert_number, :level,  :status, :certification, :comments
+  attr_accessible :category, :person_id, :courses, :expiration_date, :issued_date, :cert_number, :level,  :status, :certification, :comments
   belongs_to :person
-  belongs_to :course
+  has_and_belongs_to_many :courses
   mount_uploader :certification, CertificationUploader
   before_save :set_defaults
-  validates_presence_of :status, :person_id, :course_id, :issued_date
+  validates_presence_of :status, :person_id, :issued_date
   validates_chronology :issued_date, :expiration_date
+  validate :require_at_least_one_course
 
   scope :active, -> { where( expired: false ) }
 
@@ -32,4 +33,9 @@ class Cert < ActiveRecord::Base
     end
   end
 
+  def require_at_least_one_course
+    if courses.count == 0
+      errors.add_to_base "Please select at least one course"
+    end
+  end
 end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -3,7 +3,7 @@ class Course < ActiveRecord::Base
   include Loggable
 
   attr_accessible :category, :comments, :description, :duration, :status, :term, :name, :skill_ids
-  has_many :certs
+  has_and_belongs_to_many :certs
   has_many :people, :through => :certs
   has_many :events, :through => :certs
   has_and_belongs_to_many :skills

--- a/app/views/certs/_form.html.erb
+++ b/app/views/certs/_form.html.erb
@@ -3,7 +3,7 @@
 
   <div class="form-inputs">
     <%= f.association :person %>
-    <%= f.association :course %>
+    <%= f.association :courses %>
     <%= f.input :status, :as => :select, :collection => ['Active', 'Inactive'] %>
     <%= f.input :level, :hint => 'eg. EMT-Basic', :input_html => { :size => 22 } %>
     <%= f.input :cert_number, :label => 'Certification Number',:hint => "eg. Driver's License S number", :input_html => { :size => 22 } %>

--- a/db/migrate/20180602213542_course_habtm_certs.rb
+++ b/db/migrate/20180602213542_course_habtm_certs.rb
@@ -1,0 +1,25 @@
+class CourseHabtmCerts < ActiveRecord::Migration
+  def up
+    create_table "certs_courses" do | t |
+      t.integer :cert_id
+      t.integer :course_id
+    end
+    Cert.all.each do | c |
+      # efficient? no, but the scale is so small it doesn't really matter
+      Cert.connection.execute("insert into certs_courses (cert_id, course_id)
+                               values (#{c.id}, #{c.course_id})")
+    end
+  end
+
+  def down
+    add_column :certs, :course_id, :integer
+    Cert.connection.schema_cache.clear!
+    Cert.reset_column_information
+    Cert.connection.select_rows("SELECT cert_id, course_id FROM certs_courses").each do | row |
+      # again, not the most efficient but it'll work if you have habtm or
+      # belongs_to in your class when you run this.
+      Cert.connection.execute("update certs set course_id = #{row[1]} where id = #{row[0]}")
+    end
+    drop_table "certs_courses" if table_exists? "certs_courses"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180417162835) do
+ActiveRecord::Schema.define(version: 20180602213542) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -71,6 +71,11 @@ ActiveRecord::Schema.define(version: 20180417162835) do
   end
 
   add_index "certs", ["person_id"], name: "index_certs_on_person_id", using: :btree
+
+  create_table "certs_courses", force: :cascade do |t|
+    t.integer "cert_id"
+    t.integer "course_id"
+  end
 
   create_table "channels", force: :cascade do |t|
     t.integer  "person_id"


### PR DESCRIPTION
After speaking with @kgf it was decided that there should be a HABTM association between courses and certs, because a course can convey multiple certs.

This PR adds that functionality.

On a related note: I don't really understand why a you associated a cert with courses instead of a course with certs. I changed the cert form to support multiple courses. It doesn't _feel_ quite right but i believe that it is, because there are multiple courses that could, for example, convey the same cert. For example the long First Responder / First Aid course includes CPR training but you could also have a short CPR course that conveyed the same CPR cert. 

That being said, it feels _wrong_ that you can't choose certs when creating / editing a course. 