### PR TITLE
events archive sort by date

### DIFF
--- a/app/views/events/archives.html.erb
+++ b/app/views/events/archives.html.erb
@@ -18,10 +18,10 @@
       <tr class='<%= column_color_class(e) %>'>
         <td><%= link_to e.title, e %></td>
         <td><%= e.location %></td>
-        <td><time>
+        <td data-order='<%= e.start_time %>'><time>
           <%= e.start_time.strftime('%a, %b %d, %y %k:%M') if e.start_time  %>
         </time></td>
-        <td><time>
+        <td data-order='<%= e.end_time %>'><time>
           <%= e.end_time.strftime('%a, %b %d, %y %k:%M') if e.end_time  %>
         </time></td>
         <td><%= e.duration %></td>


### PR DESCRIPTION
added data-order attribute to the start-time and end-time <td> tags. This allows these columns to be sorted by the unformatted timestamps.
Fixes issue #598 