### PR TITLE
Added test for event#eligible_people

### DIFF
--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -60,6 +60,12 @@ RSpec.describe Event do
     expect(event.eligible_people).not_to include(user)
   end
 
+  it "only sends notifications to a certain rank and above officers" do
+    event = create(:event, min_title: "Director")
+    user = FactoryBot.create(:person, title: "Director")
+    expect(event.eligible_people).to include(user)
+  end
+
   context "finds the correct events as concurrent" do
     it "doesn't find an old event" do
       old_event = create(:event, id_code: "old", start_time: Time.at(111), end_time: Time.at(222))


### PR DESCRIPTION
Should fix #622 
 `event = create(:event, min_title: "Director")` - creates an event with minimum title _Director_
 ` user = FactoryBot.create(:person, title: "Director")` - creates a user with the title _Director_

` expect(event.eligible_people).to include(user)` - This line is supposed to evaluate to true, since the user is a _Director_.

But it does not evaluate to true.

Locally I tried changing the _event minimum title_ to _Recruiter_, _Officer_ and test still continued to fail.

Putting this PR up looking for some guidance.