### PR TITLE
712 - Don't require rank. [edited: was "Require rank only for active person"]

### DIFF
--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -35,7 +35,6 @@ class Person < ApplicationRecord
   validates_numericality_of  :height, :weight, allow_nil: true, allow_blank: true
   validates_presence_of :division2, unless: -> { division1.blank? }
   validates_presence_of :division1, unless: -> { division2.blank? }
-  validates_presence_of :title, if: -> { active? }
   validates_chronology :start_date, :end_date
 
   validate :start_date_cannot_be_before_application_date, :check_zipcode
@@ -231,10 +230,6 @@ class Person < ApplicationRecord
     upcoming_events_count = Setting.get_integer('UPCOMING_EVENTS_COUNT', 10)
 
     self.department.events.limit(upcoming_events_count)
-  end
-
-  def active?
-    status == 'Active'
   end
 
   private

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -29,12 +29,13 @@ class Person < ApplicationRecord
 
   belongs_to :department
 
-  validates_presence_of :firstname, :lastname, :status, :department, :title_order, :title
+  validates_presence_of :firstname, :lastname, :status, :department, :title_order
   validates_uniqueness_of :icsid, allow_nil: true, allow_blank: true, case_sensitive: false   # this needs to be scoped to active members, or more sophisticated rules
   validates_length_of :state, is: 2, allow_nil: true, allow_blank: true
   validates_numericality_of  :height, :weight, allow_nil: true, allow_blank: true
   validates_presence_of :division2, unless: -> { division1.blank? }
   validates_presence_of :division1, unless: -> { division2.blank? }
+  validates_presence_of :title, if: -> { active? }
   validates_chronology :start_date, :end_date
 
   validate :start_date_cannot_be_before_application_date, :check_zipcode
@@ -230,6 +231,10 @@ class Person < ApplicationRecord
     upcoming_events_count = Setting.get_integer('UPCOMING_EVENTS_COUNT', 10)
 
     self.department.events.limit(upcoming_events_count)
+  end
+
+  def active?
+    status == 'Active'
   end
 
   private

--- a/app/views/people/_form.html.erb
+++ b/app/views/people/_form.html.erb
@@ -54,7 +54,7 @@
       </div>
 
     <%= f.input :icsid, label: 'ICS id', :input_html => { :size => 5 } %>
-    <%= f.input :title, :as => :select, label: 'Rank', :collection => Person::TITLES %>
+    <%= f.input :title, :as => :select, label: 'Rank', :collection => Person::TITLES, :required => false %>
     <%= f.association :titles %>
     <%= f.input :start_date, as: :string,
                 input_html: { class: 'datepicker', size: 11,

--- a/db/migrate/20181018140320_change_person_title_as_optional.rb
+++ b/db/migrate/20181018140320_change_person_title_as_optional.rb
@@ -1,0 +1,9 @@
+class ChangePersonTitleAsOptional < ActiveRecord::Migration[5.2]
+  def up
+    change_column_null :people, :title, true
+  end
+
+  def down
+    change_column_null :people, :title, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_04_17_162835) do
+ActiveRecord::Schema.define(version: 2018_10_18_140320) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -356,7 +356,7 @@ ActiveRecord::Schema.define(version: 2018_04_17_162835) do
     t.decimal "total_hours", precision: 7, scale: 2
     t.date "start_date"
     t.date "end_date"
-    t.string "title", null: false
+    t.string "title"
     t.string "division1"
     t.string "division2"
     t.integer "position", default: 30

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -9,6 +9,40 @@ RSpec.describe Person do
     it { is_expected.to have_many(:inspectors) }
     it { is_expected.to validate_presence_of(:department) }
 
+    describe 'title presence for active person' do
+      let(:person) { build :person }
+      context 'with active status' do
+        context 'title is present' do
+          it 'is valid' do
+            expect(person.valid?).to be true
+          end
+        end
+        context 'title is not present' do
+          it 'is not valid' do
+            person.title = nil
+            expect(person.valid?).to be false
+          end
+        end
+      end
+
+      (Person::STATUS - ['Active']).each do |status|
+        context "with #{status} status" do
+          before(:each) { person.status = status }
+          context 'title is present' do
+            it 'is valid' do
+              expect(person.valid?).to be true
+            end
+          end
+          context 'title is not present' do
+            it 'is valid' do
+              person.title = nil
+              expect(person.valid?).to be true
+            end
+          end
+        end
+      end
+    end
+
     describe 'divisions' do
       context 'division 1 present' do
         it 'is invalid if division 2 is blank' do
@@ -324,4 +358,25 @@ RSpec.describe Person do
       end
     end
   end
+
+  describe 'active' do
+    let(:person) { build :person }
+
+    context 'with active status' do
+      it 'returns true' do
+        person.status = 'Active'
+        expect(person.active?).to be true
+      end
+    end
+
+    context 'with status other than active' do
+      (Person::STATUS - ['Active']).each do |status|
+        it 'returns false' do
+          person.status = status
+          expect(person.active?).to be false
+        end
+      end
+    end
+  end
+
 end

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -4,44 +4,9 @@ RSpec.describe Person do
   describe 'validations' do
     subject { build :person }
     it { is_expected.to validate_length_of(:state).is_equal_to 2 }
-    it { is_expected.to validate_presence_of(:title) }
     it { is_expected.to validate_uniqueness_of(:icsid).case_insensitive }
     it { is_expected.to have_many(:inspectors) }
     it { is_expected.to validate_presence_of(:department) }
-
-    describe 'title presence for active person' do
-      let(:person) { build :person }
-      context 'with active status' do
-        context 'title is present' do
-          it 'is valid' do
-            expect(person.valid?).to be true
-          end
-        end
-        context 'title is not present' do
-          it 'is not valid' do
-            person.title = nil
-            expect(person.valid?).to be false
-          end
-        end
-      end
-
-      (Person::STATUS - ['Active']).each do |status|
-        context "with #{status} status" do
-          before(:each) { person.status = status }
-          context 'title is present' do
-            it 'is valid' do
-              expect(person.valid?).to be true
-            end
-          end
-          context 'title is not present' do
-            it 'is valid' do
-              person.title = nil
-              expect(person.valid?).to be true
-            end
-          end
-        end
-      end
-    end
 
     describe 'divisions' do
       context 'division 1 present' do
@@ -358,25 +323,4 @@ RSpec.describe Person do
       end
     end
   end
-
-  describe 'active' do
-    let(:person) { build :person }
-
-    context 'with active status' do
-      it 'returns true' do
-        person.status = 'Active'
-        expect(person.active?).to be true
-      end
-    end
-
-    context 'with status other than active' do
-      (Person::STATUS - ['Active']).each do |status|
-        it 'returns false' do
-          person.status = status
-          expect(person.active?).to be false
-        end
-      end
-    end
-  end
-
 end


### PR DESCRIPTION
Fixes, https://github.com/ReadyResponder/ReadyResponder/issues/712

When creating or editing a person, rank/title should be required only for person with active status.
