### PR TITLE
Attempts to fix tests build on Travis CI

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -46,7 +46,7 @@ group :test, :development do
   gem 'capybara'
   # Use selenium and chrome for handling JS automated testing
   gem 'selenium-webdriver'
-  gem 'chromedriver-helper', '1.0.0'
+  gem 'webdrivers', '~> 4.0'
   gem 'guard-rspec', require: false
   gem 'guard-livereload'
   gem 'launchy'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -54,8 +54,6 @@ GEM
       public_suffix (>= 2.0.2, < 4.0)
     airbrussh (1.3.0)
       sshkit (>= 1.6.1, != 1.7.0)
-    archive-zip (0.7.0)
-      io-like (~> 0.3.0)
     arel (9.0.0)
     autoprefixer-rails (8.3.0)
       execjs
@@ -99,9 +97,6 @@ GEM
       mime-types (>= 1.16)
     childprocess (0.9.0)
       ffi (~> 1.0, >= 1.0.11)
-    chromedriver-helper (1.0.0)
-      archive-zip (~> 0.7.0)
-      nokogiri (~> 1.6)
     chunky_png (1.3.10)
     cocoon (1.2.11)
     coderay (1.1.2)
@@ -167,7 +162,6 @@ GEM
     http_parser.rb (0.6.0)
     i18n (1.0.1)
       concurrent-ruby (~> 1.0)
-    io-like (0.3.0)
     jbuilder (2.7.0)
       activesupport (>= 4.2.0)
       multi_json (>= 1.2)
@@ -397,6 +391,10 @@ GEM
       activemodel (>= 5.0)
       bindex (>= 0.4.0)
       railties (>= 5.0)
+    webdrivers (4.1.2)
+      nokogiri (~> 1.6)
+      rubyzip (~> 1.0)
+      selenium-webdriver (>= 3.0, < 4.0)
     websocket-driver (0.7.0)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.3)
@@ -416,7 +414,6 @@ DEPENDENCIES
   capistrano-rails
   capybara
   carrierwave
-  chromedriver-helper (= 1.0.0)
   cocoon
   coffee-rails (~> 4.2.2)
   database_cleaner (= 1.0.1)
@@ -465,6 +462,7 @@ DEPENDENCIES
   unicorn
   vcardigan
   web-console (~> 3.0)
+  webdrivers (~> 4.0)
 
 BUNDLED WITH
    1.16.2

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -12,20 +12,13 @@ Dir[Rails.root.join("spec/support/**/*.rb")].each {|f| require f}
 
 require 'capybara/rspec'
 require 'selenium/webdriver'
+require 'webdrivers/chromedriver'
 require 'devise'
 
 Capybara.server = :puma, { Silent: true }
-Capybara.register_driver :headless_chrome do |app|
-  capabilities = Selenium::WebDriver::Remote::Capabilities.chrome(
-    chromeOptions: { args: %w(headless disable-gpu no-sandbox) }
-  )
 
-  Capybara::Selenium::Driver.new app,
-    browser: :chrome,
-    desired_capabilities: capabilities
-end
+Capybara.javascript_driver = :selenium_chrome_headless
 
-Capybara.javascript_driver = :headless_chrome
 # Add additional requires below this line. Rails is not loaded until this point!
 
 # Requires supporting ruby files with custom matchers and macros, etc, in


### PR DESCRIPTION
(Attempts to) close #756.

Let's wait and see how tests run on Travis after thi is pushed!

Coincidentally I remember doing something similar in a previous project
when I heard the `chromedriver-helper` gem was being deprecated in favor
of the `webdrivers` gem.

Run the tests locally and all passed.

```
Finished in 5 minutes 34 seconds (files took 8.19 seconds to load)
735 examples, 0 failures, 10 pending
```